### PR TITLE
add installation/removal/launching of apps via simctl

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -18,6 +18,18 @@ function simExec (cmd:string, timeout:number, args:Array = []) {
   return Q.nfcall(cp.exec, cmd, {timeout});
 }
 
+async function installApp (udid:string, appPath:string):void {
+  await simExec("install", 0, [udid, appPath]);
+}
+
+async function removeApp (udid:string, bundleId:string):void {
+  await simExec("uninstall", 0, [udid, bundleId]);
+}
+
+async function launch (udid:string, bundleId:string):void {
+  await simExec("launch", 0, [udid, bundleId]);
+}
+
 async function createDevice (name:string, deviceTypeId:string,
     runtimeId:string):void {
   await simExec("create", 0, [name, deviceTypeId, runtimeId]);
@@ -81,4 +93,4 @@ async function getDevices (forSdk:string = null):Object {
   return devices;
 }
 
-export { createDevice, deleteDevice, eraseDevice, getDevices };
+export { installApp, removeApp, launch, createDevice, deleteDevice, eraseDevice, getDevices };


### PR DESCRIPTION
this PR adds wrappers around the `install`, `uninstall` and `launch` commands in simctl.  I'll follow up with a PR in appium to use these methods properly in the Simulator class.  

I didn't write tests for these because I thought I'd chat with you about it first - to test these I'd need to find some kind of 'hello world' app that i'll need to include in the source code to be able to install on a simulator, i'm not sure if this will even work if the simulator is not yet booted (so we'll need to shell out to instruments probably).  How do you want to proceed?