### PR TITLE
Add support for `xcrun simctl spawn`.

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -1,17 +1,24 @@
 import { exec } from 'teen_process';
 import { retryInterval } from 'asyncbox';
 import { getLogger } from 'appium-logger';
+import _ from 'lodash';
 
 
 const log = getLogger('simctl');
 
-async function simExec (command:string, timeout:number, args:Array = []) {
+async function simExec (command:string, timeout:number, args:Array = [],
+    env = {}) {
   // run a particular simctl command
   args = ['simctl', command, ...args];
   log.info(`Executing: xcrun with args: ${args.join(' ')} and timeout: ${timeout}`);
+  // Prefix all passed in environment variables with 'SIMCTL_CHILD_', simctl
+  // will then pass these to the child (spawned) process.
+  env = _.defaults(_.mapKeys(env, function(value, key) {
+    return 'SIMCTL_CHILD_' + key;
+  }), process.env);
 
   try {
-    return exec('xcrun', args, {timeout});
+    return exec('xcrun', args, {timeout, env});
   } catch (e) {
     if (e.stderr) {
       log.errorAndThrow(`simctl error: ${e.stderr.trim()}`);
@@ -31,6 +38,10 @@ async function removeApp (udid:string, bundleId:string):void {
 
 async function launch (udid:string, bundleId:string):void {
   await simExec('launch', 0, [udid, bundleId]);
+}
+
+async function spawn (udid:string, executablePath:string, env = {}):void {
+  await simExec('spawn', 0, [udid, executablePath], env);
 }
 
 async function shutdown (udid:string):void {
@@ -125,5 +136,5 @@ async function getDevices (forSdk:string = null):Object {
   return devices;
 }
 
-export { installApp, removeApp, launch, shutdown, createDevice, deleteDevice,
-         eraseDevice, getDevices };
+export { installApp, removeApp, launch, spawn, shutdown, createDevice,
+         deleteDevice, eraseDevice, getDevices };


### PR DESCRIPTION
Allows us to run WebDriverAgent (or any general executable) through simctl.