### PR TITLE
Add wait in create device

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -13,11 +13,11 @@ async function simCommand (command:string, timeout:number, args:Array = [], env 
   // Prefix all passed in environment variables with 'SIMCTL_CHILD_', simctl
   // will then pass these to the child (spawned) process.
   env = _.defaults(_.mapKeys(env, function(value, key) {
-    return 'SIMCTL_CHILD_' + key;
+    return `SIMCTL_CHILD_${key}`;
   }), process.env);
 
   try {
-    return executingFunction('xcrun', args, {timeout, env});
+    return await executingFunction('xcrun', args, {timeout, env});
   } catch (e) {
     if (e.stderr) {
       log.errorAndThrow(`simctl error: ${e.stderr.trim()}`);
@@ -28,13 +28,13 @@ async function simCommand (command:string, timeout:number, args:Array = [], env 
 }
 
 async function simExec (command:string, timeout:number, args:Array = [], env = {}) {
-  return simCommand(command, timeout, args, env, (c, a, ob) => {
-    return exec(c, a, ob);
+  return await simCommand(command, timeout, args, env, async (c, a, ob) => {
+    return await exec(c, a, ob);
   });
 }
 
 async function simSubProcess (command:string, timeout:number, args:Array = [], env = {}) {
-  return simCommand(command, timeout, args, env, async (c, a, ob) => {
+  return await simCommand(command, timeout, args, env, async (c, a, ob) => {
     return new SubProcess(c, a, ob);
   });
 }
@@ -65,21 +65,42 @@ async function shutdown (udid:string):void {
 
 async function createDevice (name:string, deviceTypeId:string,
     runtimeId:string):void {
-  let out;
+  let udid;
   try {
-    out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
+    let out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
+    udid = out.stdout.trim();
   } catch (e) {
-    log.errorAndThrow(`Could not create simulator. Reason: ${e.stderr.trim()}`);
+    if (e.stderr) {
+      log.errorAndThrow(`Could not create simulator. Reason: ${e.stderr.trim()}`);
+    } else {
+      log.errorAndThrow(e);
+    }
+
   }
-  return out.stdout.trim();
+
+  // make sure that it gets out of the "Creating" state
+  await retryInterval(10, 200, async () => {
+    let devices = await getDevices();
+    for (let deviceArr of _.values(devices)) {
+      for (let device of deviceArr) {
+        if (device.udid === udid) {
+          if (device.state === 'Creating') {
+            // need to retry
+            throw 'Device still being created';
+          } else {
+            // stop looking, we're done
+            return;
+          }
+        }
+      }
+    }
+  });
+
+  return udid;
 }
 
 async function deleteDevice (udid:string):void {
-  let loopFn:Function = async () => {
-    await simExec('delete', 0, [udid]);
-  };
-  // retry delete with a sleep in between because it's flakey
-  await retryInterval(5, 200, loopFn);
+  await simExec('delete', 0, [udid]);
 }
 
 async function eraseDevice (udid:string):void {
@@ -92,7 +113,7 @@ async function eraseDevice (udid:string):void {
 
 async function getDevices (forSdk:string = null):Object {
   // get the list of devices
-  let { stdout } = await simExec('list', 0, ['devices']);
+  let {stdout} = await simExec('list', 0, ['devices']);
 
   // expect to get a listing like
   // -- iOS 8.1 --


### PR DESCRIPTION
Some small style fixes. But the meat is (a) removing retry logic in `deleteDevice`, and (b) adding logic to `createDevice` to wait for the new device to get out of the `Creating` state.

@Jonahss 