### PR TITLE
Remove repeated log line

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -9,7 +9,6 @@ const log = getLogger('simctl');
 async function simCommand (command:string, timeout:number, args:Array = [], env = {}, executingFunction = exec) {
   // run a particular simctl command
   args = ['simctl', command, ...args];
-  log.info(`Executing: xcrun with args: ${args.join(' ')} and timeout: ${timeout}`);
   // Prefix all passed in environment variables with 'SIMCTL_CHILD_', simctl
   // will then pass these to the child (spawned) process.
   env = _.defaults(_.mapKeys(env, function(value, key) {


### PR DESCRIPTION
Remove a log line that is often repeated over and over again, as the function is called in a retry loop. The calling code can log more useful information.