### PR TITLE
Allow configurable timeouts on create and erase

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -67,7 +67,7 @@ async function shutdown (udid:string):void {
 }
 
 async function createDevice (name:string, deviceTypeId:string,
-    runtimeId:string):void {
+    runtimeId:string, timeout:int = 10000):void {
   let udid;
   try {
     let out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
@@ -82,7 +82,8 @@ async function createDevice (name:string, deviceTypeId:string,
   }
 
   // make sure that it gets out of the "Creating" state
-  await retryInterval(10, 1000, async () => {
+  let retries = timeout / 1000;
+  await retryInterval(retries, 1000, async () => {
     let devices = await getDevices();
     for (let deviceArr of _.values(devices)) {
       for (let device of deviceArr) {
@@ -106,12 +107,13 @@ async function deleteDevice (udid:string):void {
   await simExec('delete', 0, [udid]);
 }
 
-async function eraseDevice (udid:string):void {
+async function eraseDevice (udid:string, timeout:int = 1000):void {
   let loopFn:Function = async () => {
     await simExec('erase', 2000, [udid]);
   };
   // retry erase with a sleep in between because it's flakey
-  await retryInterval(5, 200, loopFn);
+  let retries = timeout / 200;
+  await retryInterval(retries, 200, loopFn);
 }
 
 async function getDevices (forSdk:string = null):Object {

--- a/test/simctl-specs.js
+++ b/test/simctl-specs.js
@@ -8,7 +8,8 @@ import { createDevice, deleteDevice, eraseDevice, getDevices } from '../lib/simc
 
 const should = chai.should();
 
-describe('simctl', () => {
+describe('simctl', function () {
+  this.timeout(20000); // enough time to allow the functions to themselves time out
   let randName;
   let randDeviceUdid = null;
   let validSdks = [];


### PR DESCRIPTION
Rather than hardcoding it, allow the calling code to say how long it should wait.