### PR TITLE
regex not working with Xcode 8. added regex to support both Xcode 8 a…

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -157,12 +157,13 @@ async function getDevices (forSdk:string = null):Object {
       //   iPhone 4s
       //   A99FFFC3-8E19-4DCF-B585-7D9D46B4C16E
       //   Shutdown
-      let lineRe:RegExp = /^    ([^\(]+) \(([^\)]+)\) \(([^\)]+)\)/;
+      let lineRe:RegExp = /([^\s].+) \((\w+-.+\w+)\) \((\w+)\)/; //https://regex101.com/r/lG7mK6/2
       let lineMatch:Object = lineRe.exec(line);
       if (lineMatch === null) {
-        throw new Error('Could not match line');
+        throw new Error(`Could not match line: ${line}`);
       }
       // save the whole thing as ab object in the list for this sdk
+
       devices[sdk].push({
         name: lineMatch[1],
         udid: lineMatch[2],


### PR DESCRIPTION
…nd previous versions.

Added line for clearer error.