### PR TITLE
State might be two words

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -157,7 +157,7 @@ async function getDevices (forSdk:string = null):Object {
       //   iPhone 4s
       //   A99FFFC3-8E19-4DCF-B585-7D9D46B4C16E
       //   Shutdown
-      let lineRe:RegExp = /([^\s].+) \((\w+-.+\w+)\) \((\w+)\)/; //https://regex101.com/r/lG7mK6/2
+      let lineRe:RegExp = /([^\s].+) \((\w+-.+\w+)\) \((\w+\s?\w+)\)/; // https://regex101.com/r/lG7mK6/3
       let lineMatch:Object = lineRe.exec(line);
       if (lineMatch === null) {
         throw new Error(`Could not match line: ${line}`);


### PR DESCRIPTION
Tiny tweak to regexp to allow for two words in the state. This occurs when a device is shutting down (state is `Shutting Down`).