### PR TITLE
Add sdk to device list for easy access in other systems

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -168,6 +168,7 @@ async function getDevices (forSdk:string = null):Object {
         name: lineMatch[1],
         udid: lineMatch[2],
         state: lineMatch[3],
+        sdk,
       });
     }
   }


### PR DESCRIPTION
Only having it at the level of the parent array makes processing more difficult in other places.