### PR TITLE
Multiple iOS Simulator Support via fbsimctl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       osx_image: xcode7
 
 install:
+  - brew tap facebook/fb
+  - brew install fbsimctl --HEAD
   - rm -rf ~/.nvm
   - git clone https://github.com/creationix/nvm.git ~/.nvm
   - source ~/.nvm/nvm.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,7 @@ language:
 matrix:
   include:
     - os: osx
-      osx_image: xcode7.3
-    - os: osx
-      osx_image: xcode7.2
-    - os: osx
-      osx_image: xcode7.1
-    - os: osx
-      osx_image: xcode7
+      osx_image: xcode8
 
 install:
   - brew tap facebook/fb

--- a/README.md
+++ b/README.md
@@ -8,7 +8,16 @@
 [![Build Status](https://travis-ci.org/appium/node-simctl.svg?branch=master)](https://travis-ci.org/appium/node-simctl)
 [![Coverage Status](https://coveralls.io/repos/appium/node-simctl/badge.svg?branch=master)](https://coveralls.io/r/appium/node-simctl?branch=master)
 
-ES6/7 Node wrapper around Apple's `simctl` binary, the "Command line utility to control the iOS Simulator". `simctl` is run as a sub-command of [xcrun](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/xcrun.1.html)
+ES6/7 Node wrapper around Facebooks `fbsimctl` library for managing iOS simulators. 
+
+Ensure you have the `fbsimctl` command installed with:
+
+````
+    # Get the Facebook Tap.
+    brew tap facebook/fb
+    # Install fbsimctl from master
+    brew install fbsimctl --HEAD
+````
 
 ### Installation
 

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -8,7 +8,7 @@ const log = getLogger('simctl');
 
 async function simCommand (command:string, timeout:number, args:Array = [], env = {}, executingFunction = exec) {
   // run a particular simctl command
-  args = ['simctl', command, ...args];
+  args = [command, ...args];
   // Prefix all passed in environment variables with 'SIMCTL_CHILD_', simctl
   // will then pass these to the child (spawned) process.
   env = _.defaults(_.mapKeys(env, function(value, key) {
@@ -16,7 +16,7 @@ async function simCommand (command:string, timeout:number, args:Array = [], env 
   }), process.env);
 
   try {
-    return await executingFunction('xcrun', args, {timeout, env});
+    return await executingFunction('fbsimctl', args, {timeout, env});
   } catch (e) {
     if (e.stderr) {
       log.errorAndThrow(`simctl error running '${command}': ${e.stderr.trim()}`);
@@ -39,16 +39,16 @@ async function simSubProcess (command:string, timeout:number, args:Array = [], e
 }
 
 async function installApp (udid:string, appPath:string):void {
-  await simExec('install', 0, [udid, appPath]);
+  await simExec(udid, 0, ['install', appPath]);
 }
 
 async function removeApp (udid:string, bundleId:string):void {
-  await simExec('uninstall', 0, [udid, bundleId]);
+  await simExec(udid, 0, ['uninstall', bundleId]);
 }
 
 async function launch (udid:string, bundleId:string, tries:int = 5):void {
   await retryInterval(tries, 1000, async () => {
-    await simExec('launch', 0, [udid, bundleId]);
+    await simExec(udid, 0, ['launch', bundleId]);
   });
 }
 
@@ -68,17 +68,21 @@ async function shutdown (udid:string):void {
   await simExec('shutdown', 0, [udid]);
 }
 
-async function createDevice (name:string, deviceTypeId:string,
+async function createDevice (deviceTypeId:string,
     runtimeId:string, timeout:int = 10000):void {
   let udid;
   try {
-    let out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
-    udid = out.stdout.trim();
+    const out = await simExec('create', 0, [deviceTypeId, runtimeId]);
+    const finalLine = _.last(out.stdout.trim().split('\n')).replace('Create Ended: ', '');
+    udid = finalLine.split('|')[0].trim();
   } catch (e) {
     if (e.stderr) {
       log.errorAndThrow(`Could not create simulator. Reason: ${e.stderr.trim()}`);
     } else {
-      log.errorAndThrow(e);
+      log.errorAndThrow(new Error(`Error creating device type: ${deviceTypeId} - Exception: `,
+        deviceTypeId,
+        e
+      ));
     }
 
   }
@@ -106,12 +110,12 @@ async function createDevice (name:string, deviceTypeId:string,
 }
 
 async function deleteDevice (udid:string):void {
-  await simExec('delete', 0, [udid]);
+  await simExec(udid, 0, ['delete']);
 }
 
 async function eraseDevice (udid:string, timeout:int = 1000):void {
   let loopFn:Function = async () => {
-    await simExec('erase', 10000, [udid]);
+    await simExec(udid, 10000, ['erase']);
   };
   // retry erase with a sleep in between because it's flakey
   let retries = parseInt(timeout / 200, 10);
@@ -120,58 +124,19 @@ async function eraseDevice (udid:string, timeout:int = 1000):void {
 
 async function getDevices (forSdk:string = null):Object {
   // get the list of devices
-  let {stdout} = await simExec('list', 0, ['devices']);
-
-  // expect to get a listing like
-  // -- iOS 8.1 --
-  //     iPhone 4s (3CA6E7DD-220E-45E5-B716-1E992B3A429C) (Shutdown)
-  //     ...
-  // -- iOS 8.2 --
-  //     iPhone 4s (A99FFFC3-8E19-4DCF-B585-7D9D46B4C16E) (Shutdown)
-  //     ...
-  // so, get the `-- iOS X.X --` line to find the sdk (X.X)
-  // and the rest of the listing in order to later find the devices
-  let deviceSectionRe:RegExp = /-- iOS (.+) --(\n    .+)*/mg;
-  let matches:Array = [];
-  let match:Object = deviceSectionRe.exec(stdout);
-
-  // make an entry for each sdk version
-  while (match !== null) {
-    matches.push(match);
-    match = deviceSectionRe.exec(stdout);
-  }
-  if (matches.length < 1) {
-    log.errorAndThrow('Could not find device section');
-  }
-
-  // get all the devices for each sdk
-  let devices:Object = {};
-  for (match of matches) {
-    let sdk:string = match[1];
-    devices[sdk] = [];
-    // split the full match into lines and remove the first
-    for (let line:string of match[0].split('\n').slice(1)) {
-      // a line is something like
-      //    iPhone 4s (A99FFFC3-8E19-4DCF-B585-7D9D46B4C16E) (Shutdown)
-      // retrieve:
-      //   iPhone 4s
-      //   A99FFFC3-8E19-4DCF-B585-7D9D46B4C16E
-      //   Shutdown
-      let lineRe:RegExp = /([^\s].+) \((\w+-.+\w+)\) \((\w+\s?\w+)\)/; // https://regex101.com/r/lG7mK6/3
-      let lineMatch:Object = lineRe.exec(line);
-      if (lineMatch === null) {
-        throw new Error(`Could not match line: ${line}`);
-      }
-      // save the whole thing as ab object in the list for this sdk
-
-      devices[sdk].push({
-        name: lineMatch[1],
-        udid: lineMatch[2],
-        state: lineMatch[3],
-        sdk,
-      });
-    }
-  }
+  const {stdout} = await simExec('list', 0);
+  const devices:Object = {};
+  const items = stdout.trim().split('\n');
+  for (const item of items) {
+    const itemSegments = item.split('|').map((x) => x.trim());
+    const sdk = itemSegments[4];
+    devices[sdk] = devices[sdk] || [];
+    devices[sdk].push({
+      udid: itemSegments[0],
+      name: itemSegments[1],  // 1 or 3? Seems either suits in fbsimctl 
+      state: itemSegments[2], // since names arent customizable.
+    });
+  } 
 
   // if a `forSdk` was passed in, return only the corresponding list
   if (forSdk) {


### PR DESCRIPTION
Hey,

The native xcrun/simctl setup has no support for multiple concurrent emulators at present. Facebooks alternative, fbsimctl has support for this. This isn't intended to go in as-is, but should start the discussion. The changes I'm seeing as required would be along the lines of:
- This or something much like it.
- Pushing this dependency update into the upstream appium projects.
- Patching anywhere else that seems to limit iOS simulators to 1.

I'd appreciate a steer on this.

(Expecting initial few builds to fail as I'm not able to easily cross-test various xcodes at home).
