### PR TITLE
Allow getAppContainer to run without logging

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -6,7 +6,7 @@ import _ from 'lodash';
 
 const log = getLogger('simctl');
 
-async function simCommand (command:string, timeout:number, args:Array = [], env = {}, executingFunction = exec) {
+async function simCommand (command:string, timeout:number, args:Array = [], env = {}, executingFunction = exec, logErrors = true) {
   // run a particular simctl command
   args = ['simctl', command, ...args];
   // Prefix all passed in environment variables with 'SIMCTL_CHILD_', simctl
@@ -18,7 +18,11 @@ async function simCommand (command:string, timeout:number, args:Array = [], env 
   try {
     return await executingFunction('xcrun', args, {timeout, env});
   } catch (e) {
-    if (e.stderr) {
+    if (!logErrors) {
+      // if we don't want to see the errors, just throw and allow the calling
+      // code do what it wants
+      throw e;
+    } else if (e.stderr) {
       log.errorAndThrow(`simctl error running '${command}': ${e.stderr.trim()}`);
     } else {
       log.errorAndThrow(e);
@@ -26,10 +30,10 @@ async function simCommand (command:string, timeout:number, args:Array = [], env 
   }
 }
 
-async function simExec (command:string, timeout:number, args:Array = [], env = {}) {
+async function simExec (command:string, timeout:number, args:Array = [], env = {}, logErrors = true) {
   return await simCommand(command, timeout, args, env, async (c, a, ob) => {
     return await exec(c, a, ob);
-  });
+  }, logErrors);
 }
 
 async function simSubProcess (command:string, timeout:number, args:Array = [], env = {}) {
@@ -68,8 +72,8 @@ async function terminate (udid:string, bundleId:string):void {
   await simExec('terminate', 0, [udid, bundleId]);
 }
 
-async function getAppContainer (udid:string, bundleId:string) {
-  return await simExec('get_app_container', 0, [udid, bundleId]).stdout.trim();
+async function getAppContainer (udid:string, bundleId:string, logErrors = true) {
+  return await simExec('get_app_container', 0, [udid, bundleId], {}, logErrors).stdout.trim();
 }
 
 async function shutdown (udid:string):void {


### PR DESCRIPTION
Set up the machinery for allowing an optional parameter to a method to block logging. At this point the only need for this is `getAppContainer`, which _should_ throw an error if there is no app container (i.e., if the app is not installed) and so we don't want logging, since that signals to the user that there was a problem.

In future other methods may have valid reasons to do the same. Right now they will function as they always have.