### PR TITLE
Add test and fix for getDevices function

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -215,7 +215,7 @@ async function getDevices (forSdk:string = null):Object {
       let sdk = sdkName.replace('iOS ', '');
       devices[sdk] = entries.map((el) => {
         delete el.availability;
-        return el;
+        return {...el, sdk};
       });
     }
   } catch (err) {

--- a/test/simctl-specs.js
+++ b/test/simctl-specs.js
@@ -81,4 +81,12 @@ describe('simctl', function () {
     deleteDevice(udid);
   });
 
+  it('should create a device with compatible properties', async () => {
+    let sdk = _.last(validSdks);
+    let devices = (await getDevices())[sdk]
+    let firstDevice = devices[0]
+    let expectedList = ['name', 'sdk', 'state', 'udid']
+    Object.keys(firstDevice).sort().should.eql(expectedList)
+  });
+
 });


### PR DESCRIPTION
Hi!

I've started Appium today and got an error:
```bash
-------------------------------------
Error while executing tests:
A new session could not be created. Details: Appium's IosDriver does not support xcode version 8.2.1. Apple has deprecated UIAutomation. Use the "XCUITest" automationName capability instead.
-------------------------------------
Stack:
{ status: 33,
  type: 'SessionNotCreatedException',
  message: 'A new session could not be created.',
  orgStatusMessage: 'A new session could not be created. Details: Appium\'s IosDriver does not support xcode version 8.2.1. Apple has deprecated UIAutomation. Use the "XCUITest" automationName capability instead.' }
-------------------------------------
```

I thought looks like one of deps was updated and it was `node-simctl`.
New `getDevices` mechanism was buggy and implemented without tests.
I have fixed this problem.