### PR TITLE
Add method to get runtime for platform

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -6,6 +6,9 @@ import _ from 'lodash';
 
 const log = logger.getLogger('simctl');
 
+// https://regex101.com/r/UykjQZ/1
+const IOS_RUNTIME_REGEXP = /iOS (\d+\.\d+) \((\d+\.\d+\.*\d*)/;
+
 async function simCommand (command:string, timeout:number, args:Array = [], env = {}, executingFunction = exec, logErrors = true) {
   // run a particular simctl command
   args = ['simctl', command, ...args];
@@ -84,6 +87,14 @@ async function shutdown (udid:string):void {
 async function createDevice (name:string, deviceTypeId:string,
     runtimeId:string, timeout:int = 10000):void {
   let udid;
+  // first make sure that the runtime id is the right one
+  // in some versions of xcode it will be a patch version
+  try {
+    runtimeId = await getRuntimeForPlatformVersion(runtimeId);
+  } catch (err) {
+    log.warn(`Unable to find runtime for iOS '${runtimeId}'. Continuing`);
+  }
+
   try {
     let out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
     udid = out.stdout.trim();
@@ -236,9 +247,27 @@ async function getDevices (forSdk:string = null):Object {
   return devices;
 }
 
+async function getRuntimeForPlatformVersion (platformVersion) {
+  try {
+    // let {stdout} = await exec('xcrun', ['simctl', 'list', 'runtimes']);
+    let {stdout} = await simExec('list', 0, ['runtimes']);
+    for (let line of stdout.split('\n')) {
+      let match = IOS_RUNTIME_REGEXP.exec(line);
+      if (match) {
+        if (match[1] === platformVersion) {
+          return match[2];
+        }
+      }
+    }
+  } catch (ign) {}
+
+  // if nothing was found, pass platform version back
+  return platformVersion;
+}
+
 /**
  * Gets base64 screenshot for device (xcode >= 8.1 only)
- * @param {string} udid 
+ * @param {string} udid
  */
 async function getScreenshot (udid:string):string {
   let pathToScreenshotPng = await tempDir.path({prefix: `screenshot-${udid}`, suffix: '.png'});
@@ -248,5 +277,6 @@ async function getScreenshot (udid:string):string {
   return screenshotImg.toString('base64');
 }
 
-export { installApp, removeApp, launch, spawn, spawnSubProcess, openUrl, terminate, shutdown, createDevice,
-         getAppContainer, getScreenshot, deleteDevice, eraseDevice, getDevices };
+export { installApp, removeApp, launch, spawn, spawnSubProcess, openUrl,
+         terminate, shutdown, createDevice, getAppContainer, getScreenshot,
+         deleteDevice, eraseDevice, getDevices, getRuntimeForPlatformVersion };


### PR DESCRIPTION
If xcode has a sim with a patch version (like Xcode 8.3.3, which has iOS 10.3.1 instead of 10.3) creating a device will fail.