### PR TITLE
Add boot command to the list of API wrappers

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -49,6 +49,10 @@ async function installApp (udid:string, appPath:string):void {
   await simExec('install', 0, [udid, appPath]);
 }
 
+async function bootDevice (udid:string):void {
+  await simExec('boot', 0, [udid]);
+}
+
 async function removeApp (udid:string, bundleId:string):void {
   await simExec('uninstall', 0, [udid, bundleId]);
 }


### PR DESCRIPTION
This will be extremely useful for iOS11, since now simctl actually controls headless simulation server and can control multiple virtual devices without UI.