### PR TITLE
Fix bootDevice and add eslint to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - npm install -g gulp
 
 script:
-  - _FORCE_LOGS=1 gulp test
+  - gulp eslint && _FORCE_LOGS=1 gulp test
 
 after_success:
     - gulp coveralls

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -283,4 +283,5 @@ async function getScreenshot (udid:string):string {
 
 export { installApp, removeApp, launch, spawn, spawnSubProcess, openUrl,
          terminate, shutdown, createDevice, getAppContainer, getScreenshot,
-         deleteDevice, eraseDevice, getDevices, getRuntimeForPlatformVersion };
+         deleteDevice, eraseDevice, getDevices, getRuntimeForPlatformVersion,
+         bootDevice };


### PR DESCRIPTION
`bootDevice` was added as a method but not exported. Eslint failed.

Added eslint to Travis config so even if a developer skips the pre-commit hooks, the build will fail.