### PR TITLE
Improve the error message for missing Simulator SDK

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -292,7 +292,12 @@ async function getDevices (forSdk:string = null):Object {
   // if a `forSdk` was passed in, return only the corresponding list
   if (forSdk) {
     if (!devices[forSdk]) {
-      throw new Error(`Sdk '${forSdk}' was not in list of simctl sdks`);
+      let errMsg = `'${forSdk}' does not exist in the list of simctl SDKs.`;
+      const availableSDKs = _.keys(devices);
+      errMsg += availableSDKs.length ?
+        ` Only the following Simulator SDK versions are available on your system: ${availableSDKs}` :
+        ` No Simulator SDK versions are available on your system. Please install some via Xcode preferences.`;
+      throw new Error(errMsg);
     }
     return devices[forSdk];
   }


### PR DESCRIPTION
I observe that it is sometimes unclear to users why the platformVersion they set in capabilities does not match any of the available Simulators. This PR should improve the situation by printing a better error message.