### PR TITLE
Get rid of arrow functions in mocha aparatus

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,18 +42,19 @@
     "mocha": "mocha",
     "coverage": "gulp coveralls",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
-    "lint": "gulp eslint"
+    "lint": "gulp eslint",
+    "lint:fix": "gulp eslint --fix"
   },
   "pre-commit": [
     "precommit-msg",
     "test"
   ],
   "devDependencies": {
-    "appium-gulp-plugins": "^2.1.5",
+    "appium-gulp-plugins": "^2.2.1",
     "babel-eslint": "^7.1.1",
     "chai": "^3.2.0",
     "eslint": "^3.10.2",
-    "eslint-config-appium": "^2.0.1",
+    "eslint-config-appium": "^2.1.0",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-flowtype": "^2.30.0",
     "eslint-plugin-import": "^2.2.0",

--- a/test/simctl-e2e-specs.js
+++ b/test/simctl-e2e-specs.js
@@ -22,7 +22,7 @@ describe('simctl', function () {
   let randDeviceUdid = null;
   let validSdks = [];
 
-  before(async () => {
+  before(async function () {
     let devices = await getDevices();
     validSdks = _.keys(devices).sort((a, b) => a - b);
     if (!validSdks.length) {


### PR DESCRIPTION
Add a gulp task for fixing eslint. And fix the arrow functions in mocha.

appium/appium#10016