### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-node_modules/
-*.log
-*.un~
-_vimrc_local.vim
-*.swp
-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,19 @@ matrix:
     - osx_image: xcode7.3
       node_js: "8"
     - osx_image: xcode7.3
-      node_js: "6"
+      node_js: "10"
     - osx_image: xcode8.3
       node_js: "8"
     - osx_image: xcode8.3
-      node_js: "6"
+      node_js: "10"
     - osx_image: xcode9.4
       node_js: "8"
     - osx_image: xcode9.4
-      node_js: "6"
+      node_js: "10"
     - osx_image: xcode10
       node_js: "8"
     - osx_image: xcode10
-      node_js: "6"
+      node_js: "10"
 script:
   - _FORCE_LOGS=1 npm run test && npm run e2e-test
 after_success:

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -92,7 +92,7 @@ async function simExec (command, timeout, args = [], env = {}, logErrors = true)
  * @return {SubProcess} The instance of teen_process's SubProcess class.
  */
 async function simSubProcess (command, timeout, args = [], env = {}) {
-  return await simCommand(command, timeout, args, env, async (c, a, ob) => {
+  return await simCommand(command, timeout, args, env, (c, a, ob) => {
     return new SubProcess(c, a, ob);
   });
 }
@@ -527,7 +527,7 @@ async function getDevices (forSdk = null) {
      * }
      */
     devices = {};
-    for (let [sdkName, entries]  of _.toPairs(JSON.parse(stdout).devices)) {
+    for (let [sdkName, entries] of _.toPairs(JSON.parse(stdout).devices)) {
       if (sdkName.indexOf('iOS') !== 0) {
         continue;
       }
@@ -682,8 +682,9 @@ async function getDeviceTypes () {
 }
 
 
-export { installApp, removeApp, launch, spawn, spawnSubProcess, openUrl,
-         terminate, shutdown, createDevice, getAppContainer, getScreenshot,
-         deleteDevice, eraseDevice, getDevices, getRuntimeForPlatformVersion,
-         bootDevice, setPasteboard, getPasteboard, addMedia, appInfo,
-         getDeviceTypes };
+export {
+  installApp, removeApp, launch, spawn, spawnSubProcess, openUrl, terminate,
+  shutdown, createDevice, getAppContainer, getScreenshot, deleteDevice,
+  eraseDevice, getDevices, getRuntimeForPlatformVersion, bootDevice,
+  setPasteboard, getPasteboard, addMedia, appInfo, getDeviceTypes,
+};

--- a/package.json
+++ b/package.json
@@ -24,18 +24,22 @@
   "directories": {
     "lib": "./lib"
   },
+  "files": [
+    "lib",
+    "build/lib"
+  ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "appium-support": "^2.4.0",
     "appium-xcode": "^3.1.0",
     "asyncbox": "^2.3.1",
-    "babel-runtime": "=5.8.24",
     "lodash": "^4.2.1",
     "source-map-support": "^0.5.5",
     "teen_process": "^1.5.1"
   },
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
-    "prepublish": "gulp prepublish",
+    "prepare": "gulp prepublish",
     "test": "gulp once",
     "watch": "gulp watch",
     "build": "gulp transpile",
@@ -51,32 +55,23 @@
     "test"
   ],
   "devDependencies": {
-    "appium-gulp-plugins": "^2.2.1",
-    "babel-eslint": "^7.1.1",
+    "ajv": "^6.5.3",
+    "appium-gulp-plugins": "^3.1.0",
+    "babel-eslint": "^10.0.0",
+    "bluebird": "^3.5.1",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^3.10.2",
-    "eslint-config-appium": "^2.1.0",
-    "eslint-plugin-babel": "^3.3.0",
+    "eslint": "^5.2.0",
+    "eslint-config-appium": "^3.1.0",
     "eslint-plugin-flowtype": "^2.30.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-promise": "^3.3.1",
-    "gulp": "^3.9.0",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-promise": "^4.0.0",
+    "gulp": "^4.0.0",
     "mocha": "^5.1.1",
     "pre-commit": "^1.1.3"
   },
   "greenkeeper": {
-    "ignore": [
-      "babel-eslint",
-      "babel-preset-env",
-      "eslint",
-      "eslint-plugin-babel",
-      "eslint-plugin-import",
-      "eslint-plugin-mocha",
-      "eslint-plugin-promise",
-      "gulp",
-      "babel-runtime"
-    ]
+    "ignore": []
   }
 }

--- a/test/simctl-e2e-specs.js
+++ b/test/simctl-e2e-specs.js
@@ -143,7 +143,7 @@ describe('simctl', function () {
 
     describe('pasteboard', function () {
       let pbRetries = 0;
-      before(async function () {
+      before(function () {
         if (major < 8 || (major === 8 && minor < 1)) {
           return this.skip();
         }


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.