### PR TITLE
Make sure the boot monitoring process is properly killed after the timeout

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -680,12 +680,12 @@ async function getDeviceTypes () {
 
 /**
  * @typedef {Object} BootMonitorOptions
- * @property {?number} timeout [240000] - Simulator booting timeout in ms. This property only makes sense if
- * `onFinished` is unset.
+ * @property {?number} timeout [240000] - Simulator booting timeout in ms.
  * @property {?Function} onWaitingDataMigration - This event is fired when data migration stage starts.
  * @property {?Function} onWaitingSystemApp - This event is fired when system app wait stage starts.
  * @property {?Function} onFinished - This event is fired when Simulator is fully booted.
- * @property {?Function} onError - This event is fired when there was an error while monitoring the booting process.
+ * @property {?Function} onError - This event is fired when there was an error while monitoring the booting process
+ * or when the timeout has expired.
  */
 
 /**
@@ -712,6 +712,7 @@ async function startBootMonitor (udid, opts = {}) {
   let status = '';
   let isBootingFinished = false;
   let error = null;
+  let timeoutHandler = null;
   const bootMonitor = await simSubProcess('bootstatus', 0, [udid]);
   bootMonitor.on('output', (stdout, stderr) => {
     status += stdout || stderr;
@@ -723,22 +724,36 @@ async function startBootMonitor (udid, opts = {}) {
       }
     }
   });
-  bootMonitor.on('exit', (code) => {
+  bootMonitor.on('exit', (code, signal) => {
+    if (timeoutHandler) {
+      clearTimeout(timeoutHandler);
+    }
     if (code === 0) {
       if (onFinished) {
         onFinished();
       }
       isBootingFinished = true;
     } else {
-      error = new Error(status);
+      error = new Error(status || signal);
       if (onError) {
         onError(error);
       }
     }
   });
   await bootMonitor.start(0);
+  const stopMonitor = async () => {
+    if (bootMonitor.isRunning) {
+      try {
+        await bootMonitor.stop();
+      } catch (e) {
+        log.warn(e.message);
+      }
+    }
+  };
   const timeStarted = process.hrtime();
-  if (!onFinished) {
+  if (onFinished) {
+    timeoutHandler = setTimeout(stopMonitor, timeout);
+  } else {
     try {
       await waitForCondition(() => {
         if (error) {
@@ -747,6 +762,7 @@ async function startBootMonitor (udid, opts = {}) {
         return isBootingFinished;
       }, {waitMs: timeout, intervalMs: 500});
     } catch (err) {
+      await stopMonitor();
       throw new Error(`The simulator ${udid} has failed to finish booting after ${process.hrtime(timeStarted)[0]}s. ` +
         `Original status: ${status}`);
     }

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -734,7 +734,8 @@ async function startBootMonitor (udid, opts = {}) {
       }
       isBootingFinished = true;
     } else {
-      error = new Error(status || signal);
+      status = status || signal;
+      error = new Error(status);
       if (onError) {
         onError(error);
       }


### PR DESCRIPTION
I've noticed that `bootstatus` command makes the process to wait forever if one tries to start it for Simulator, which exists, but has not been booted. This PR makes sure the waiting process is killed after the timeout expires.