### PR TITLE
By default get all devices in getDevices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ matrix:
       node_js: "8"
     - osx_image: xcode10
       node_js: "10"
+    - osx_image: xcode10.1
+      node_js: "8"
+    - osx_image: xcode10.1
+      node_js: "10"
 script:
   - _FORCE_LOGS=1 npm run test && npm run e2e-test
 after_success:

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -3,9 +3,8 @@ import { retryInterval, waitForCondition } from 'asyncbox';
 import { logger, fs, tempDir } from 'appium-support';
 import _ from 'lodash';
 
-const log = logger.getLogger('simctl');
 
-const IOS_PLATFORM = 'iOS';
+const log = logger.getLogger('simctl');
 
 /**
  * Execute the particular simctl command and return the output.
@@ -425,14 +424,14 @@ async function eraseDevice (udid, timeout = 1000) {
  * Parse the list of existing Simulator devices to represent
  * it as convenient mapping.
  *
- * @param {?string} platform [iOS] - The platform name, for example 'watchOS'.
+ * @param {?string} platform - The platform name, for example 'watchOS'.
  * @return {Object} The resulting mapping. Each key is platform version,
  *                  for example '10.3' and the corresponding value is an
  *                  array of the matching {@link DeviceInfo} instances.
  * @throws {Error} If the corresponding simctl subcommand command
  *                 returns non-zero return code.
  */
-async function getDevicesByParsing (platform = IOS_PLATFORM) {
+async function getDevicesByParsing (platform) {
   // get the list of devices
   const {stdout} = await simExec('list', 0, ['devices']);
 
@@ -445,7 +444,9 @@ async function getDevicesByParsing (platform = IOS_PLATFORM) {
   //     ...
   // so, get the `-- iOS X.X --` line to find the sdk (X.X)
   // and the rest of the listing in order to later find the devices
-  const deviceSectionRe = new RegExp(`\\-\\-\\s+${_.escapeRegExp(platform)}\\s+(\\S+)\\s+\\-\\-(\\n\\s{4}.+)*`, 'mgi');
+  const deviceSectionRe = _.isEmpty(platform)
+    ? new RegExp(`\\-\\-\\s+\\S+\\s+(\\S+)\\s+\\-\\-(\\n\\s{4}.+)*`, 'mgi')
+    : new RegExp(`\\-\\-\\s+${_.escapeRegExp(platform)}\\s+(\\S+)\\s+\\-\\-(\\n\\s{4}.+)*`, 'mgi');
   const matches = [];
   let match;
   // make an entry for each sdk version
@@ -461,7 +462,7 @@ async function getDevicesByParsing (platform = IOS_PLATFORM) {
   const devices = {};
   for (match of matches) {
     const sdk = match[1];
-    devices[sdk] = [];
+    devices[sdk] = devices[sdk] || [];
     // split the full match into lines and remove the first
     for (const line of match[0].split('\n').slice(1)) {
       // a line is something like
@@ -493,7 +494,7 @@ async function getDevicesByParsing (platform = IOS_PLATFORM) {
  * @param {?string} forSdk - The sdk version,
  *                           for which the devices list should be parsed,
  *                           for example '10.3'.
- * @param {?string} platform [iOS] - The platform name, for example 'watchOS'.
+ * @param {?string} platform - The platform name, for example 'watchOS'.
  * @return {Object|Array<DeviceInfo>} If _forSdk_ is set then the list
  *                                    of devices for the particular platform version.
  *                                    Otherwise the same result as for {@link getDevicesByParsing}
@@ -502,7 +503,7 @@ async function getDevicesByParsing (platform = IOS_PLATFORM) {
  *                 returns non-zero return code or if no matching
  *                 platform version is found in the system.
  */
-async function getDevices (forSdk = null, platform = IOS_PLATFORM) {
+async function getDevices (forSdk = null, platform) {
   let devices = {};
   try {
     const {stdout} = await simExec('list', 0, ['devices', '-j']);
@@ -520,19 +521,23 @@ async function getDevices (forSdk = null, platform = IOS_PLATFORM) {
      *   }
      * }
      */
-    const versionMatchRe = new RegExp(`^${_.escapeRegExp(platform)}\\s+(\\S+)`, 'i');
+    const versionMatchRe = _.isEmpty(platform)
+      ? new RegExp(`^\\S+\\s+(\\S+)`, 'i')
+      : new RegExp(`^${_.escapeRegExp(platform)}\\s+(\\S+)`, 'i');
     for (const [sdkName, entries] of _.toPairs(JSON.parse(stdout).devices)) {
       const versionMatch = versionMatchRe.exec(sdkName);
       if (!versionMatch) {
         continue;
       }
-      devices[versionMatch[1]] = entries.map((el) => {
+      const sdk = versionMatch[1];
+      devices[sdk] = devices[sdk] || [];
+      devices[sdk].push(...entries.map((el) => {
         delete el.availability;
         return {
+          sdk,
           ...el,
-          sdk: versionMatch[1]
         };
-      });
+      }));
     }
   } catch (err) {
     log.debug(`Unable to get JSON device list: ${err.stack}`);
@@ -556,12 +561,13 @@ async function getDevices (forSdk = null, platform = IOS_PLATFORM) {
   throw new Error(errMsg);
 }
 
+
 /**
  * Get the runtime for the particular platform version.
  *
  * @param {string} platformVersion - The platform version name,
  *                                   for example '10.3'.
- * @param {?string} platform [iOS] - The platform name, for example 'watchOS'.
+ * @param {?string} platform - The platform name, for example 'watchOS'.
  * @return {string} The corresponding runtime name for the given
  *                  platform version.
  */


### PR DESCRIPTION
Rather than defaulting to `iOS`, get _all_ devices. This makes downstream changes to support non-iOS based simulators much easier.

**This is a breaking change.**