### PR TITLE
Adjust getDevices and add unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
     - osx_image: xcode10.1
       node_js: "10"
 script:
-  - _FORCE_LOGS=1 npm run test && npm run e2e-test
+  - xcrun simctl list devices
+  - npm run test && _FORCE_LOGS=1 npm run e2e-test
 after_success:
     - npm run coverage

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -509,7 +509,17 @@ async function getDevicesByParsing (platform) {
  *                 returns non-zero return code or if no matching
  *                 platform version is found in the system.
  */
-async function getDevices (forSdk = null, platform) {
+async function getDevices (forSdk, platform) {
+  let msg = 'Retrieving available simulators';
+  if (forSdk && platform) {
+    msg += ` for SDK '${forSdk}' and platform '${platform}'`;
+  } else if (forSdk) {
+    msg += ` for SDK '${forSdk}'`;
+  } else if (platform) {
+    msg += ` for platform '${platform}'`;
+  }
+  log.debug(msg);
+
   let devices = {};
   try {
     const {stdout} = await simExec('list', 0, ['devices', '-j']);

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -6,6 +6,8 @@ import _ from 'lodash';
 
 const log = logger.getLogger('simctl');
 
+const SIM_RUNTIME_NAME = 'com.apple.CoreSimulator.SimRuntime.';
+
 /**
  * Execute the particular simctl command and return the output.
  *
@@ -349,7 +351,7 @@ async function createDevice (name, deviceTypeId, runtimeId, timeout = 10000) {
 
   log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${runtimeId}'`);
   try {
-    let out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
+    const out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
     udid = out.stdout.trim();
   } catch (err) {
     let reason = err.message;
@@ -364,8 +366,8 @@ async function createDevice (name, deviceTypeId, runtimeId, timeout = 10000) {
   let retries = parseInt(timeout / 1000, 10);
   await retryInterval(retries, 1000, async () => {
     let devices = await getDevices();
-    for (let deviceArr of _.values(devices)) {
-      for (let device of deviceArr) {
+    for (const deviceArr of _.values(devices)) {
+      for (const device of deviceArr) {
         if (device.udid === udid) {
           if (device.state === 'Creating') {
             // need to retry
@@ -445,7 +447,7 @@ async function getDevicesByParsing (platform) {
   // so, get the `-- iOS X.X --` line to find the sdk (X.X)
   // and the rest of the listing in order to later find the devices
   const deviceSectionRe = _.isEmpty(platform)
-    ? new RegExp(`\\-\\-\\s+\\S+\\s+(\\S+)\\s+\\-\\-(\\n\\s{4}.+)*`, 'mgi')
+    ? new RegExp(`\\-\\-\\s+(\\S+)\\s+(\\S+)\\s+\\-\\-(\\n\\s{4}.+)*`, 'mgi')
     : new RegExp(`\\-\\-\\s+${_.escapeRegExp(platform)}\\s+(\\S+)\\s+\\-\\-(\\n\\s{4}.+)*`, 'mgi');
   const matches = [];
   let match;
@@ -461,10 +463,13 @@ async function getDevicesByParsing (platform) {
   // get all the devices for each sdk
   const devices = {};
   for (match of matches) {
-    const sdk = match[1];
+    const sdk = platform ? match[1] : match[2];
     devices[sdk] = devices[sdk] || [];
     // split the full match into lines and remove the first
     for (const line of match[0].split('\n').slice(1)) {
+      if (line.includes('(unavailable, ')) {
+        continue;
+      }
       // a line is something like
       //    iPhone 4s (A99FFFC3-8E19-4DCF-B585-7D9D46B4C16E) (Shutdown)
       // retrieve:
@@ -481,6 +486,7 @@ async function getDevicesByParsing (platform) {
         udid: lineMatch[2],
         state: lineMatch[3],
         sdk,
+        platform: platform || match[1],
       });
     }
   }
@@ -510,10 +516,12 @@ async function getDevices (forSdk = null, platform) {
     /* JSON should be
      * {
      *   "devices" : {
-     *     "iOS <sdk>" : [
+     *     "iOS <sdk>" : [ // or
+     *     "com.apple.CoreSimulator.SimRuntime.iOS-<sdk> : [
      *       {
      *         "state" : "Booted",
      *         "availability" : "(available)",
+     *         "isAvailable" : true,
      *         "name" : "iPhone 6",
      *         "udid" : "75E34140-18E8-4D1A-9F45-AAC735DF75DF"
      *       }
@@ -522,22 +530,29 @@ async function getDevices (forSdk = null, platform) {
      * }
      */
     const versionMatchRe = _.isEmpty(platform)
-      ? new RegExp(`^\\S+\\s+(\\S+)`, 'i')
-      : new RegExp(`^${_.escapeRegExp(platform)}\\s+(\\S+)`, 'i');
-    for (const [sdkName, entries] of _.toPairs(JSON.parse(stdout).devices)) {
+      ? new RegExp(`^([^\\s-]+)[\\s-](\\S+)`, 'i')
+      : new RegExp(`^${_.escapeRegExp(platform)}[\\s-](\\S+)`, 'i');
+    for (let [sdkName, entries] of _.toPairs(JSON.parse(stdout).devices)) {
+      // there could be a longer name, so remove it
+      sdkName = sdkName.replace(SIM_RUNTIME_NAME, '');
       const versionMatch = versionMatchRe.exec(sdkName);
       if (!versionMatch) {
         continue;
       }
-      const sdk = versionMatch[1];
+
+      // the sdk can have dashes (`12-2`) or dots (`12.1`)
+      const sdk = (platform ? versionMatch[1] : versionMatch[2]).replace('-', '.');
       devices[sdk] = devices[sdk] || [];
-      devices[sdk].push(...entries.map((el) => {
-        delete el.availability;
-        return {
-          sdk,
-          ...el,
-        };
-      }));
+      devices[sdk].push(...entries.filter((el) => _.isUndefined(el.isAvailable) || el.isAvailable)
+        .map((el) => {
+          delete el.availability;
+          return {
+            sdk,
+            ...el,
+            platform: platform || versionMatch[1],
+          };
+        })
+      );
     }
   } catch (err) {
     log.debug(`Unable to get JSON device list: ${err.stack}`);
@@ -545,11 +560,23 @@ async function getDevices (forSdk = null, platform) {
     devices = await getDevicesByParsing(platform);
   }
 
+  function logDevices (sdk, sims) {
+    for (const sim of sims) {
+      log.debug(`  ${sim.name} (${sim.platform} ${sdk}) [${sim.udid}] (${sim.state})`);
+    }
+  }
+
   if (!forSdk) {
+    log.debug('Available simulators:');
+    for (const [sdk, sims] of _.toPairs(devices)) {
+      logDevices(sdk, sims);
+    }
     return devices;
   }
   // if a `forSdk` was passed in, return only the corresponding list
   if (devices[forSdk]) {
+    log.debug('Available simulators:');
+    logDevices(forSdk, devices[forSdk]);
     return devices[forSdk];
   }
 

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -534,11 +534,14 @@ async function getDevices (forSdk = null, platform) {
       : new RegExp(`^${_.escapeRegExp(platform)}[\\s-](\\S+)`, 'i');
     for (let [sdkName, entries] of _.toPairs(JSON.parse(stdout).devices)) {
       // there could be a longer name, so remove it
+      log.debug(`SDK: '${sdkName}'`);
       sdkName = sdkName.replace(SIM_RUNTIME_NAME, '');
+      log.debug(`  '${sdkName}'`);
       const versionMatch = versionMatchRe.exec(sdkName);
       if (!versionMatch) {
         continue;
       }
+      log.debug(`  ${versionMatch}`);
 
       // the sdk can have dashes (`12-2`) or dots (`12.1`)
       const sdk = (platform ? versionMatch[1] : versionMatch[2]).replace('-', '.');

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -510,16 +510,6 @@ async function getDevicesByParsing (platform) {
  *                 platform version is found in the system.
  */
 async function getDevices (forSdk, platform) {
-  let msg = 'Retrieving available simulators';
-  if (forSdk && platform) {
-    msg += ` for SDK '${forSdk}' and platform '${platform}'`;
-  } else if (forSdk) {
-    msg += ` for SDK '${forSdk}'`;
-  } else if (platform) {
-    msg += ` for platform '${platform}'`;
-  }
-  log.debug(msg);
-
   let devices = {};
   try {
     const {stdout} = await simExec('list', 0, ['devices', '-j']);
@@ -544,14 +534,11 @@ async function getDevices (forSdk, platform) {
       : new RegExp(`^${_.escapeRegExp(platform)}[\\s-](\\S+)`, 'i');
     for (let [sdkName, entries] of _.toPairs(JSON.parse(stdout).devices)) {
       // there could be a longer name, so remove it
-      log.debug(`SDK: '${sdkName}'`);
       sdkName = sdkName.replace(SIM_RUNTIME_NAME, '');
-      log.debug(`  '${sdkName}'`);
       const versionMatch = versionMatchRe.exec(sdkName);
       if (!versionMatch) {
         continue;
       }
-      log.debug(`  ${versionMatch}`);
 
       // the sdk can have dashes (`12-2`) or dots (`12.1`)
       const sdk = (platform ? versionMatch[1] : versionMatch[2]).replace('-', '.');
@@ -579,8 +566,8 @@ async function getDevices (forSdk, platform) {
     }
   }
 
+  log.debug('Available simulators:');
   if (!forSdk) {
-    log.debug('Available simulators:');
     for (const [sdk, sims] of _.toPairs(devices)) {
       logDevices(sdk, sims);
     }
@@ -588,7 +575,6 @@ async function getDevices (forSdk, platform) {
   }
   // if a `forSdk` was passed in, return only the corresponding list
   if (devices[forSdk]) {
-    log.debug('Available simulators:');
     logDevices(forSdk, devices[forSdk]);
     return devices[forSdk];
   }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "eslint-plugin-promise": "^4.0.0",
     "gulp": "^4.0.0",
     "mocha": "^5.1.1",
-    "pre-commit": "^1.1.3"
+    "pre-commit": "^1.1.3",
+    "sinon": "^7.2.3"
   },
   "greenkeeper": {
     "ignore": []

--- a/test/fixtures/devices-simple.json
+++ b/test/fixtures/devices-simple.json
@@ -1,0 +1,138 @@
+{
+  "devices" : {
+    "tvOS 12.1" : [
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple TV",
+        "udid" : "FA628127-1D5C-45C3-9918-A47BF7E2AE14",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple TV 4K",
+        "udid" : "2EF493BE-E7D5-45E7-9725-8D2706F7220E",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple TV 4K (at 1080p)",
+        "udid" : "FFECD143-B523-4A3D-BA27-1F9706F814CB",
+        "availabilityError" : ""
+      }
+    ],
+    "iOS 12.1" : [
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPhone 5s",
+        "udid" : "E17597CE-71EE-4402-8B1C-1B526446A3A2",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPhone 6",
+        "udid" : "1C7AB8B9-94C3-4806-86D7-77C13B483902",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPhone 6 Plus",
+        "udid" : "EE76EA77-E975-4198-9859-69DFF74252D2",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Air",
+        "udid" : "225C4FDB-5132-423A-9CFF-89D4474395F9",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Air 2",
+        "udid" : "DDDF281C-F912-471C-B30D-994A2644DF03",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Pro (12.9-inch)",
+        "udid" : "1D953CFF-1FBC-413E-B2AB-B4BA4DD5EEC2",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Pro (12.9-inch) (2nd generation)",
+        "udid" : "A7D1A0D7-D67B-409F-A73D-0DB53EDD860F",
+        "availabilityError" : ""
+      }
+    ],
+    "watchOS 5.1" : [
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 2 - 38mm",
+        "udid" : "F40113CC-2973-4EBD-87F4-31852A6FF09B",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 2 - 42mm",
+        "udid" : "5A83C524-FFF6-45AA-936C-365D2F1126F3",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 3 - 38mm",
+        "udid" : "C76C585D-96D1-4037-80ED-C73DBBDB3521",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 3 - 42mm",
+        "udid" : "DA5E98A8-2D04-474F-A0C3-9A0234F44CC9",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 4 - 40mm",
+        "udid" : "DCD321B8-F265-4213-B248-C89AB8B806E1",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 4 - 44mm",
+        "udid" : "EADBBE94-E97C-4D13-9FF2-44A3524113C7",
+        "availabilityError" : ""
+      }
+    ]
+  }
+}

--- a/test/fixtures/devices-with-unavailable-simple.json
+++ b/test/fixtures/devices-with-unavailable-simple.json
@@ -1,0 +1,272 @@
+{
+  "devices" : {
+    "tvOS 12.1" : [
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple TV",
+        "udid" : "FA628127-1D5C-45C3-9918-A47BF7E2AE14",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple TV 4K",
+        "udid" : "2EF493BE-E7D5-45E7-9725-8D2706F7220E",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple TV 4K (at 1080p)",
+        "udid" : "FFECD143-B523-4A3D-BA27-1F9706F814CB",
+        "availabilityError" : ""
+      }
+    ],
+    "iOS 12.1" : [
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPhone 5s",
+        "udid" : "E17597CE-71EE-4402-8B1C-1B526446A3A2",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPhone 6",
+        "udid" : "1C7AB8B9-94C3-4806-86D7-77C13B483902",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPhone 6 Plus",
+        "udid" : "EE76EA77-E975-4198-9859-69DFF74252D2",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Air",
+        "udid" : "225C4FDB-5132-423A-9CFF-89D4474395F9",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Air 2",
+        "udid" : "DDDF281C-F912-471C-B30D-994A2644DF03",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Pro (12.9-inch)",
+        "udid" : "1D953CFF-1FBC-413E-B2AB-B4BA4DD5EEC2",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Pro (12.9-inch) (2nd generation)",
+        "udid" : "A7D1A0D7-D67B-409F-A73D-0DB53EDD860F",
+        "availabilityError" : ""
+      }
+    ],
+    "tvOS 12.2" : [
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple TV",
+        "udid" : "84793AD4-E1C9-49EE-B85A-0DCBB0806279",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple TV 4K",
+        "udid" : "B3ABE34D-7F23-4107-B381-3DD0184134D1",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple TV 4K (at 1080p)",
+        "udid" : "289113A3-52A3-4904-B7B6-E66DF666EDB5",
+        "availabilityError" : "runtime profile not found"
+      }
+    ],
+    "watchOS 5.2" : [
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple Watch Series 2 - 38mm",
+        "udid" : "76D3F91D-5C60-4B9B-A30A-A01A63C6FE73",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple Watch Series 2 - 42mm",
+        "udid" : "26B36BEB-A564-4321-A108-72DEEB2D63F9",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple Watch Series 3 - 38mm",
+        "udid" : "63D10205-08E3-4A8C-9334-DB0868D87554",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple Watch Series 3 - 42mm",
+        "udid" : "420CD468-9CED-44F7-A8AE-F1FABB18BFB2",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple Watch Series 4 - 40mm",
+        "udid" : "6E507921-8AE9-4562-93C6-52DFDA87EA40",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple Watch Series 4 - 44mm",
+        "udid" : "E5DDFDFA-693A-46A7-B42A-866681E15B83",
+        "availabilityError" : "runtime profile not found"
+      }
+    ],
+    "watchOS 5.1" : [
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 2 - 38mm",
+        "udid" : "F40113CC-2973-4EBD-87F4-31852A6FF09B",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 2 - 42mm",
+        "udid" : "5A83C524-FFF6-45AA-936C-365D2F1126F3",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 3 - 38mm",
+        "udid" : "C76C585D-96D1-4037-80ED-C73DBBDB3521",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 3 - 42mm",
+        "udid" : "DA5E98A8-2D04-474F-A0C3-9A0234F44CC9",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 4 - 40mm",
+        "udid" : "DCD321B8-F265-4213-B248-C89AB8B806E1",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 4 - 44mm",
+        "udid" : "EADBBE94-E97C-4D13-9FF2-44A3524113C7",
+        "availabilityError" : ""
+      }
+    ],
+    "iOS 12.2" : [
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "iPhone 5s",
+        "udid" : "DBC918BB-D519-408D-A5E7-EAD66D875A40",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "iPhone 6",
+        "udid" : "5CC1A69E-75B0-4109-8474-61C605C61493",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "iPhone 6 Plus",
+        "udid" : "99FE1BB4-66F4-47CA-A144-9198A5CBB9B6",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "iPad Air",
+        "udid" : "F78CD721-6DB1-4C19-9601-FEB84D2D0A12",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "iPad Air 2",
+        "udid" : "7E3B9E66-5995-4342-929C-43CCFF4E0819",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "iPad Pro (12.9-inch)",
+        "udid" : "D5483905-8384-4F9A-B337-AE5B7F6B6994",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "iPad Pro (12.9-inch) (2nd generation)",
+        "udid" : "DDC7CD7C-8E12-42AF-B39A-DB847CCD84FD",
+        "availabilityError" : "runtime profile not found"
+      }
+    ]
+  }
+}

--- a/test/fixtures/devices-with-unavailable.json
+++ b/test/fixtures/devices-with-unavailable.json
@@ -1,0 +1,272 @@
+{
+  "devices" : {
+    "com.apple.CoreSimulator.SimRuntime.tvOS-12-1" : [
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple TV",
+        "udid" : "FA628127-1D5C-45C3-9918-A47BF7E2AE14",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple TV 4K",
+        "udid" : "2EF493BE-E7D5-45E7-9725-8D2706F7220E",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple TV 4K (at 1080p)",
+        "udid" : "FFECD143-B523-4A3D-BA27-1F9706F814CB",
+        "availabilityError" : ""
+      }
+    ],
+    "com.apple.CoreSimulator.SimRuntime.iOS-12-1" : [
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPhone 5s",
+        "udid" : "E17597CE-71EE-4402-8B1C-1B526446A3A2",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPhone 6",
+        "udid" : "1C7AB8B9-94C3-4806-86D7-77C13B483902",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPhone 6 Plus",
+        "udid" : "EE76EA77-E975-4198-9859-69DFF74252D2",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Air",
+        "udid" : "225C4FDB-5132-423A-9CFF-89D4474395F9",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Air 2",
+        "udid" : "DDDF281C-F912-471C-B30D-994A2644DF03",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Pro (12.9-inch)",
+        "udid" : "1D953CFF-1FBC-413E-B2AB-B4BA4DD5EEC2",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Pro (12.9-inch) (2nd generation)",
+        "udid" : "A7D1A0D7-D67B-409F-A73D-0DB53EDD860F",
+        "availabilityError" : ""
+      }
+    ],
+    "com.apple.CoreSimulator.SimRuntime.tvOS-12-2" : [
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple TV",
+        "udid" : "84793AD4-E1C9-49EE-B85A-0DCBB0806279",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple TV 4K",
+        "udid" : "B3ABE34D-7F23-4107-B381-3DD0184134D1",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple TV 4K (at 1080p)",
+        "udid" : "289113A3-52A3-4904-B7B6-E66DF666EDB5",
+        "availabilityError" : "runtime profile not found"
+      }
+    ],
+    "com.apple.CoreSimulator.SimRuntime.watchOS-5-2" : [
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple Watch Series 2 - 38mm",
+        "udid" : "76D3F91D-5C60-4B9B-A30A-A01A63C6FE73",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple Watch Series 2 - 42mm",
+        "udid" : "26B36BEB-A564-4321-A108-72DEEB2D63F9",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple Watch Series 3 - 38mm",
+        "udid" : "63D10205-08E3-4A8C-9334-DB0868D87554",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple Watch Series 3 - 42mm",
+        "udid" : "420CD468-9CED-44F7-A8AE-F1FABB18BFB2",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple Watch Series 4 - 40mm",
+        "udid" : "6E507921-8AE9-4562-93C6-52DFDA87EA40",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "Apple Watch Series 4 - 44mm",
+        "udid" : "E5DDFDFA-693A-46A7-B42A-866681E15B83",
+        "availabilityError" : "runtime profile not found"
+      }
+    ],
+    "com.apple.CoreSimulator.SimRuntime.watchOS-5-1" : [
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 2 - 38mm",
+        "udid" : "F40113CC-2973-4EBD-87F4-31852A6FF09B",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 2 - 42mm",
+        "udid" : "5A83C524-FFF6-45AA-936C-365D2F1126F3",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 3 - 38mm",
+        "udid" : "C76C585D-96D1-4037-80ED-C73DBBDB3521",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 3 - 42mm",
+        "udid" : "DA5E98A8-2D04-474F-A0C3-9A0234F44CC9",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 4 - 40mm",
+        "udid" : "DCD321B8-F265-4213-B248-C89AB8B806E1",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 4 - 44mm",
+        "udid" : "EADBBE94-E97C-4D13-9FF2-44A3524113C7",
+        "availabilityError" : ""
+      }
+    ],
+    "com.apple.CoreSimulator.SimRuntime.iOS-12-2" : [
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "iPhone 5s",
+        "udid" : "DBC918BB-D519-408D-A5E7-EAD66D875A40",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "iPhone 6",
+        "udid" : "5CC1A69E-75B0-4109-8474-61C605C61493",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "iPhone 6 Plus",
+        "udid" : "99FE1BB4-66F4-47CA-A144-9198A5CBB9B6",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "iPad Air",
+        "udid" : "F78CD721-6DB1-4C19-9601-FEB84D2D0A12",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "iPad Air 2",
+        "udid" : "7E3B9E66-5995-4342-929C-43CCFF4E0819",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "iPad Pro (12.9-inch)",
+        "udid" : "D5483905-8384-4F9A-B337-AE5B7F6B6994",
+        "availabilityError" : "runtime profile not found"
+      },
+      {
+        "availability" : "(unavailable, runtime profile not found)",
+        "state" : "Shutdown",
+        "isAvailable" : false,
+        "name" : "iPad Pro (12.9-inch) (2nd generation)",
+        "udid" : "DDC7CD7C-8E12-42AF-B39A-DB847CCD84FD",
+        "availabilityError" : "runtime profile not found"
+      }
+    ]
+  }
+}

--- a/test/fixtures/devices.json
+++ b/test/fixtures/devices.json
@@ -1,0 +1,138 @@
+{
+  "devices" : {
+    "com.apple.CoreSimulator.SimRuntime.tvOS-12-1" : [
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple TV",
+        "udid" : "FA628127-1D5C-45C3-9918-A47BF7E2AE14",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple TV 4K",
+        "udid" : "2EF493BE-E7D5-45E7-9725-8D2706F7220E",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple TV 4K (at 1080p)",
+        "udid" : "FFECD143-B523-4A3D-BA27-1F9706F814CB",
+        "availabilityError" : ""
+      }
+    ],
+    "com.apple.CoreSimulator.SimRuntime.iOS-12-1" : [
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPhone 5s",
+        "udid" : "E17597CE-71EE-4402-8B1C-1B526446A3A2",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPhone 6",
+        "udid" : "1C7AB8B9-94C3-4806-86D7-77C13B483902",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPhone 6 Plus",
+        "udid" : "EE76EA77-E975-4198-9859-69DFF74252D2",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Air",
+        "udid" : "225C4FDB-5132-423A-9CFF-89D4474395F9",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Air 2",
+        "udid" : "DDDF281C-F912-471C-B30D-994A2644DF03",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Pro (12.9-inch)",
+        "udid" : "1D953CFF-1FBC-413E-B2AB-B4BA4DD5EEC2",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "iPad Pro (12.9-inch) (2nd generation)",
+        "udid" : "A7D1A0D7-D67B-409F-A73D-0DB53EDD860F",
+        "availabilityError" : ""
+      }
+    ],
+    "com.apple.CoreSimulator.SimRuntime.watchOS-5-1" : [
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 2 - 38mm",
+        "udid" : "F40113CC-2973-4EBD-87F4-31852A6FF09B",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 2 - 42mm",
+        "udid" : "5A83C524-FFF6-45AA-936C-365D2F1126F3",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 3 - 38mm",
+        "udid" : "C76C585D-96D1-4037-80ED-C73DBBDB3521",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 3 - 42mm",
+        "udid" : "DA5E98A8-2D04-474F-A0C3-9A0234F44CC9",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 4 - 40mm",
+        "udid" : "DCD321B8-F265-4213-B248-C89AB8B806E1",
+        "availabilityError" : ""
+      },
+      {
+        "availability" : "(available)",
+        "state" : "Shutdown",
+        "isAvailable" : true,
+        "name" : "Apple Watch Series 4 - 44mm",
+        "udid" : "EADBBE94-E97C-4D13-9FF2-44A3524113C7",
+        "availabilityError" : ""
+      }
+    ]
+  }
+}

--- a/test/simctl-e2e-specs.js
+++ b/test/simctl-e2e-specs.js
@@ -26,7 +26,9 @@ describe('simctl', function () {
 
   before(async function () {
     const devices = await getDevices();
-    validSdks = _.keys(devices).sort((a, b) => a - b);
+    validSdks = _.keys(devices)
+      .filter((key) => !_.isEmpty(devices[key]))
+      .sort((a, b) => a - b);
     if (!validSdks.length) {
       throw new Error('No valid SDKs');
     }

--- a/test/simctl-specs.js
+++ b/test/simctl-specs.js
@@ -1,2 +1,118 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import * as TeenProcess from 'teen_process';
+import _ from 'lodash';
+import { getDevices } from '../lib/simctl';
+
+
+const devicePayloads = [
+  [
+    {
+      stdout: JSON.stringify(require('../../test/fixtures/devices.json')), // eslint-disable-line no-unresolved
+    },
+    {
+      stdout: JSON.stringify(require('../../test/fixtures/devices-with-unavailable.json')), // eslint-disable-line no-unresolved
+    },
+  ],
+  [
+    {
+      stdout: JSON.stringify(require('../../test/fixtures/devices-simple.json')), // eslint-disable-line no-unresolved
+    },
+    {
+      stdout: JSON.stringify(require('../../test/fixtures/devices-with-unavailable-simple.json')), // eslint-disable-line no-unresolved
+    },
+  ],
+];
+
+chai.should();
+chai.use(chaiAsPromised);
+
 describe('simctl', function () {
+  describe('getDevices', function () {
+    const execStub = sinon.stub(TeenProcess, 'exec');
+    afterEach(function () {
+      execStub.resetHistory();
+    });
+    after(function () {
+      execStub.reset();
+    });
+
+    for (const [devicesPayload, devicesWithUnavailablePayload] of devicePayloads) {
+      describe('no forSdk defined', function () {
+        describe('no platform defined', function () {
+          it('should get all the devices in the JSON', async function () {
+            execStub.returns(devicesPayload);
+
+            const devices = await getDevices();
+            _.keys(devices).length.should.eql(2);
+
+            devices['12.1'].length.should.eql(10);
+            devices['5.1'].length.should.eql(6);
+          });
+          it('should ignore unavailable devices', async function () {
+            execStub.returns(devicesWithUnavailablePayload);
+
+            const devices = await getDevices();
+            _.keys(devices).length.should.eql(4);
+
+            devices['12.1'].length.should.eql(10);
+            devices['5.1'].length.should.eql(6);
+            devices['12.2'].length.should.eql(0);
+            devices['5.2'].length.should.eql(0);
+          });
+        });
+        describe('platform defined', function () {
+          it('should get all the devices in the JSON', async function () {
+            execStub.returns(devicesPayload);
+
+            const devices = await getDevices(null, 'tvOS');
+            _.keys(devices).length.should.eql(1);
+
+            devices['12.1'].length.should.eql(3);
+          });
+          it('should ignore unavailable devices', async function () {
+            execStub.returns(devicesWithUnavailablePayload);
+
+            const devices = await getDevices(null, 'tvOS');
+            _.keys(devices).length.should.eql(2);
+
+            devices['12.1'].length.should.eql(3);
+            devices['12.2'].length.should.eql(0);
+          });
+        });
+      });
+
+      describe('forSdk defined', function () {
+        describe('no platform defined', function () {
+          it('should get all the devices in the JSON', async function () {
+            execStub.returns(devicesPayload);
+
+            const devices = await getDevices('12.1');
+            _.keys(devices).length.should.eql(10);
+          });
+          it('should ignore unavailable devices', async function () {
+            execStub.returns(devicesWithUnavailablePayload);
+
+            const devices = await getDevices('12.1');
+            _.keys(devices).length.should.eql(10);
+          });
+        });
+        describe('platform defined', function () {
+          it('should get all the devices in the JSON', async function () {
+            execStub.returns(devicesPayload);
+
+            const devices = await getDevices('5.1', 'watchOS');
+            _.keys(devices).length.should.eql(6);
+          });
+          it('should ignore unavailable devices', async function () {
+            execStub.returns(devicesWithUnavailablePayload);
+
+            const devices = await getDevices('5.1', 'watchOS');
+            _.keys(devices).length.should.eql(6);
+          });
+        });
+      });
+    }
+  });
 });


### PR DESCRIPTION
There are cases where the platform and sdk are listed as we expect (e.g., `iOS 12.2`) and cases where they are in a different form (e.g., `com.apple.CoreSimulator.SimRuntime.iOS-12-2`). This PR makes accommodations for that variance.

It also puts the platform into the simulator info object, so that downstream consumers know what sort of device it is.

And finally, it adds unit tests for the JSON-based parsing of devices.