### PR TITLE
fix creating simulators for new format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
       node_js: "8"
     - osx_image: xcode10.2
       node_js: "10"
+      env:
+        - DEVICE_NAME="iPhone X"
 script:
   - xcrun simctl list devices
   - npm run test && _FORCE_LOGS=1 npm run e2e-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ matrix:
       node_js: "8"
     - osx_image: xcode7.3
       node_js: "10"
-    - osx_image: xcode8.3
-      node_js: "8"
-    - osx_image: xcode8.3
-      node_js: "10"
     - osx_image: xcode9.4
       node_js: "8"
     - osx_image: xcode9.4
@@ -25,6 +21,10 @@ matrix:
     - osx_image: xcode10.1
       node_js: "8"
     - osx_image: xcode10.1
+      node_js: "10"
+    - osx_image: xcode10.2
+      node_js: "8"
+    - osx_image: xcode10.2
       node_js: "10"
 script:
   - xcrun simctl list devices

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
       node_js: "10"
     - osx_image: xcode10.2
       node_js: "8"
+      env:
+        - DEVICE_NAME="iPhone X"
     - osx_image: xcode10.2
       node_js: "10"
       env:

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -11,6 +11,7 @@ const CLT_FORMAT_CHANGED_VERSION = '10.2';
 
 const SIM_RUNTIME_NAME = 'com.apple.CoreSimulator.SimRuntime.';
 const SIM_RUNTIME_NAME_SUFFIX = 'iOS';
+const DEFAULT_CREATE_SIMULATOR_TIMEOUT = 10000;
 
 /**
  * Execute the particular simctl command and return the output.
@@ -333,6 +334,8 @@ async function shutdown (udid) {
 /**
  * @typedef {Object} SimCreationOpts
  * @property {string} platform [iOS] - Platform name in order to specify runtime such as 'iOS', 'tvOS', 'watchOS'
+ * @property {number} timeout [10000] - The maximum number of milliseconds to wait
+ *                                      unit device creation is completed.
  */
 /**
  * Create Simulator device with given name for the particular
@@ -341,16 +344,15 @@ async function shutdown (udid) {
  * @param {string} name - The device name to be created.
  * @param {string} deviceTypeId - Device type, for example 'iPhone 6'.
  * @param {string} runtimeId - Platform version, for example '10.3'.
- * @param {number} timeout [10000] - The maximum number of milliseconds to wait
- *                                   unit device creation is completed.
  * @param {?SimCreationOpts} opts - Simulator options for creating devives
  * @return {string} The UDID of the newly created device.
  * @throws {Error} If the corresponding simctl subcommand command
  *                 returns non-zero return code.
  */
-async function createDevice (name, deviceTypeId, runtimeId, timeout = 10000, opts = {}) {
+async function createDevice (name, deviceTypeId, runtimeId, opts = {}) {
   const {
-    platform = SIM_RUNTIME_NAME_SUFFIX
+    platform = SIM_RUNTIME_NAME_SUFFIX,
+    timeout = DEFAULT_CREATE_SIMULATOR_TIMEOUT
   } = opts;
 
   let udid;

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -358,17 +358,17 @@ async function createDevice (name, deviceTypeId, runtimeId, timeout = 10000, opt
     log.warn(`Unable to find runtime for iOS '${runtimeId}'. Continuing`);
   }
 
-  const runtime = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace('.', '-')}`;
+  const newRuntimeId = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace('.', '-')}`;
   try {
     let out;
     try {
       // Over Xcode 10.2 requires here.
       // Environment which has installed Xcode 10.2 once also requires here even if
       // the environment change xcode version with xcode-select.
-      log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime '${runtime}'`);
-      out = await simExec('create', 0, [name, deviceTypeId, runtime]);
+      log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${newRuntimeId}'`);
+      out = await simExec('create', 0, [name, deviceTypeId, newRuntimeId]);
     } catch (err) {
-      log.debug(`Faled to create simulator with '${runtime}'. Try to create old format`);
+      log.debug(`Faled to create simulator with '${newRuntimeId}': ${err.message}. Try to create old format as fallback`);
       log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${runtimeId}'`);
       out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
     }
@@ -379,7 +379,7 @@ async function createDevice (name, deviceTypeId, runtimeId, timeout = 10000, opt
       reason = err.stderr.trim();
     }
     log.errorAndThrow(`Could not create simulator with name '${name}', device ` +
-                      `type id '${deviceTypeId}' and runtime id '${runtimeId}'. Reason: '${reason}'`);
+                      `type id '${deviceTypeId}' and runtime id '${newRuntimeId}' and '${runtimeId}'. Reason: '${reason}'`);
   }
 
   // make sure that it gets out of the "Creating" state

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -7,10 +7,10 @@ import { getCommandLineToolsVersion } from 'appium-xcode';
 
 const log = logger.getLogger('simctl');
 
-const CLT_FORMAT_CHANGED_VERSION = '10.2';
+const CMDLINE_TOOLS_FORMAT_CHANGED_VERSION = '10.2';
 
 const SIM_RUNTIME_NAME = 'com.apple.CoreSimulator.SimRuntime.';
-const SIM_RUNTIME_NAME_SUFFIX = 'iOS';
+const SIM_RUNTIME_NAME_SUFFIX_IOS = 'iOS';
 const DEFAULT_CREATE_SIMULATOR_TIMEOUT = 10000;
 
 /**
@@ -351,7 +351,7 @@ async function shutdown (udid) {
  */
 async function createDevice (name, deviceTypeId, runtimeId, opts = {}) {
   const {
-    platform = SIM_RUNTIME_NAME_SUFFIX,
+    platform = SIM_RUNTIME_NAME_SUFFIX_IOS,
     timeout = DEFAULT_CREATE_SIMULATOR_TIMEOUT
   } = opts;
 
@@ -364,8 +364,8 @@ async function createDevice (name, deviceTypeId, runtimeId, opts = {}) {
     log.warn(`Unable to find runtime for iOS '${runtimeId}'. Continuing`);
   }
 
-  const cltVersion = getCommandLineToolsVersion();
-  if (util.compareVersions(cltVersion, '>=', CLT_FORMAT_CHANGED_VERSION)) {
+  const cltVersion = await getCommandLineToolsVersion();
+  if (util.compareVersions(cltVersion, '>=', CMDLINE_TOOLS_FORMAT_CHANGED_VERSION)) {
     runtimeId = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace('.', '-')}`;
   }
 

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -344,7 +344,7 @@ async function shutdown (udid) {
  * @param {string} name - The device name to be created.
  * @param {string} deviceTypeId - Device type, for example 'iPhone 6'.
  * @param {string} runtimeId - Platform version, for example '10.3'.
- * @param {?SimCreationOpts} opts - Simulator options for creating devives
+ * @param {?SimCreationOpts} opts - Simulator options for creating devices.
  * @return {string} The UDID of the newly created device.
  * @throws {Error} If the corresponding simctl subcommand command
  *                 returns non-zero return code.

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -366,10 +366,12 @@ async function createDevice (name, deviceTypeId, runtimeId, opts = {}) {
     log.warn(`Unable to find runtime for iOS '${runtimeId}'. Continuing`);
   }
 
-  if (util.compareVersions(await getCommandLineToolsVersion(), '>=', CMDLINE_TOOLS_FORMAT_CHANGED_VERSION)) {
+  if (util.compareVersions(await getCommandLineToolsVersion(), '>=', CMDLINE_TOOLS_FORMAT_CHANGED_VERSION)
+      || util.compareVersions(await getVersion(false), '>=', XCODE_FORMAT_CHANGED_VERSION)) {
+    // 1st comparison: getCommandLineToolsVersion
     // Command line tool version is 10.2+, but xcode 10.1 can happen
-    runtimeId = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace(/\./g, '-')}`;
-  } else if (util.compareVersions(await getVersion(false), '>=', XCODE_FORMAT_CHANGED_VERSION)) {
+
+    // 2nd comparison: getVersion
     // The opposit also can happen,
     // but the combination of 10.2 command line tool and lower Xcode version happens frequently than this case
     // On Travis's Xcode 10.2 image happens, for instance

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -366,7 +366,7 @@ async function createDevice (name, deviceTypeId, runtimeId, opts = {}) {
 
   const cltVersion = await getCommandLineToolsVersion();
   if (util.compareVersions(cltVersion, '>=', CMDLINE_TOOLS_FORMAT_CHANGED_VERSION)) {
-    runtimeId = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace('.', '-')}`;
+    runtimeId = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace(/\./g, '-')}`;
   }
 
   log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${runtimeId}'`);

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -2,12 +2,14 @@ import { exec, SubProcess } from 'teen_process';
 import { retryInterval, waitForCondition } from 'asyncbox';
 import { logger, fs, tempDir, util } from 'appium-support';
 import _ from 'lodash';
-import { getCommandLineToolsVersion } from 'appium-xcode';
+import { getCommandLineToolsVersion, getVersion } from 'appium-xcode';
 
 
 const log = logger.getLogger('simctl');
 
+// command line tools and xcode version can be different
 const CMDLINE_TOOLS_FORMAT_CHANGED_VERSION = '10.2';
+const XCODE_FORMAT_CHANGED_VERSION = '10.2';
 
 const SIM_RUNTIME_NAME = 'com.apple.CoreSimulator.SimRuntime.';
 const SIM_RUNTIME_NAME_SUFFIX_IOS = 'iOS';
@@ -364,8 +366,13 @@ async function createDevice (name, deviceTypeId, runtimeId, opts = {}) {
     log.warn(`Unable to find runtime for iOS '${runtimeId}'. Continuing`);
   }
 
-  const cltVersion = await getCommandLineToolsVersion();
-  if (util.compareVersions(cltVersion, '>=', CMDLINE_TOOLS_FORMAT_CHANGED_VERSION)) {
+  if (util.compareVersions(await getCommandLineToolsVersion(), '>=', CMDLINE_TOOLS_FORMAT_CHANGED_VERSION)) {
+    // Command line tool version is 10.2+, but xcode 10.1 can happen
+    runtimeId = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace(/\./g, '-')}`;
+  } else if (util.compareVersions(await getVersion(false), '>=', XCODE_FORMAT_CHANGED_VERSION)) {
+    // The opposit also can happen,
+    // but the combination of 10.2 command line tool and lower Xcode version happens frequently than this case
+    // On Travis's Xcode 10.2 image happens, for instance
     runtimeId = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace(/\./g, '-')}`;
   }
 

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -1,12 +1,16 @@
 import { exec, SubProcess } from 'teen_process';
 import { retryInterval, waitForCondition } from 'asyncbox';
-import { logger, fs, tempDir } from 'appium-support';
+import { logger, fs, tempDir, util } from 'appium-support';
 import _ from 'lodash';
+import { getCommandLineToolsVersion } from 'appium-xcode';
 
 
 const log = logger.getLogger('simctl');
 
+const CLT_FORMAT_CHANGED_VERSION = '10.2';
+
 const SIM_RUNTIME_NAME = 'com.apple.CoreSimulator.SimRuntime.';
+const SIM_RUNTIME_NAME_SUFFIX = 'iOS';
 
 /**
  * Execute the particular simctl command and return the output.
@@ -327,8 +331,8 @@ async function shutdown (udid) {
 }
 
 /**
- * @typedef {Object} SimDeviceOpts
- * @property {string} platform - Platform name in order to specify runtime such as 'iOS', 'tvOS', 'watchOS'
+ * @typedef {Object} SimCreationOpts
+ * @property {string} platform [iOS] - Platform name in order to specify runtime such as 'iOS', 'tvOS', 'watchOS'
  */
 /**
  * Create Simulator device with given name for the particular
@@ -339,14 +343,14 @@ async function shutdown (udid) {
  * @param {string} runtimeId - Platform version, for example '10.3'.
  * @param {number} timeout [10000] - The maximum number of milliseconds to wait
  *                                   unit device creation is completed.
- * @param {?SimDeviceOpts} opts - Simulator options for creating devives
+ * @param {?SimCreationOpts} opts - Simulator options for creating devives
  * @return {string} The UDID of the newly created device.
  * @throws {Error} If the corresponding simctl subcommand command
  *                 returns non-zero return code.
  */
 async function createDevice (name, deviceTypeId, runtimeId, timeout = 10000, opts = {}) {
   const {
-    platform = 'iOS'
+    platform = SIM_RUNTIME_NAME_SUFFIX
   } = opts;
 
   let udid;
@@ -358,20 +362,14 @@ async function createDevice (name, deviceTypeId, runtimeId, timeout = 10000, opt
     log.warn(`Unable to find runtime for iOS '${runtimeId}'. Continuing`);
   }
 
-  const newRuntimeId = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace('.', '-')}`;
+  const cltVersion = getCommandLineToolsVersion();
+  if (util.compareVersions(cltVersion, '>=', CLT_FORMAT_CHANGED_VERSION)) {
+    runtimeId = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace('.', '-')}`;
+  }
+
+  log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${runtimeId}'`);
   try {
-    let out;
-    try {
-      // Over Xcode 10.2 requires here.
-      // Environment which has installed Xcode 10.2 once also requires here even if
-      // the environment change xcode version with xcode-select.
-      log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${newRuntimeId}'`);
-      out = await simExec('create', 0, [name, deviceTypeId, newRuntimeId]);
-    } catch (err) {
-      log.debug(`Faled to create simulator with '${newRuntimeId}': ${err.message}. Try to create old format as fallback`);
-      log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${runtimeId}'`);
-      out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
-    }
+    const out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
     udid = out.stdout.trim();
   } catch (err) {
     let reason = err.message;
@@ -379,7 +377,7 @@ async function createDevice (name, deviceTypeId, runtimeId, timeout = 10000, opt
       reason = err.stderr.trim();
     }
     log.errorAndThrow(`Could not create simulator with name '${name}', device ` +
-                      `type id '${deviceTypeId}' and runtime id '${newRuntimeId}' and '${runtimeId}'. Reason: '${reason}'`);
+                      `type id '${deviceTypeId}' and runtime id '${runtimeId}'. Reason: '${reason}'`);
   }
 
   // make sure that it gets out of the "Creating" state

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -327,6 +327,10 @@ async function shutdown (udid) {
 }
 
 /**
+ * @typedef {Object} SimDeviceOpts
+ * @property {string} platform - Platform name in order to specify runtime such as 'iOS', 'tvOS', 'watchOS'
+ */
+/**
  * Create Simulator device with given name for the particular
  * platform type and version.
  *
@@ -335,23 +339,39 @@ async function shutdown (udid) {
  * @param {string} runtimeId - Platform version, for example '10.3'.
  * @param {number} timeout [10000] - The maximum number of milliseconds to wait
  *                                   unit device creation is completed.
+ * @param {?SimDeviceOpts} opts - Simulator options for creating devives
  * @return {string} The UDID of the newly created device.
  * @throws {Error} If the corresponding simctl subcommand command
  *                 returns non-zero return code.
  */
-async function createDevice (name, deviceTypeId, runtimeId, timeout = 10000) {
+async function createDevice (name, deviceTypeId, runtimeId, timeout = 10000, opts = {}) {
+  const {
+    platform = 'iOS'
+  } = opts;
+
   let udid;
   // first make sure that the runtime id is the right one
   // in some versions of Xcode it will be a patch version
   try {
-    runtimeId = await getRuntimeForPlatformVersion(runtimeId);
+    runtimeId = await getRuntimeForPlatformVersion(runtimeId, platform);
   } catch (err) {
     log.warn(`Unable to find runtime for iOS '${runtimeId}'. Continuing`);
   }
 
-  log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${runtimeId}'`);
+  const runtime = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace('.', '-')}`;
   try {
-    const out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
+    let out;
+    try {
+      // Over Xcode 10.2 requires here.
+      // Environment which has installed Xcode 10.2 once also requires here even if
+      // the environment change xcode version with xcode-select.
+      log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime '${runtime}'`);
+      out = await simExec('create', 0, [name, deviceTypeId, runtime]);
+    } catch (err) {
+      log.debug(`Faled to create simulator with '${runtime}'. Try to create old format`);
+      log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${runtimeId}'`);
+      out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
+    }
     udid = out.stdout.trim();
   } catch (err) {
     let reason = err.message;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-support": "^2.4.0",
+    "appium-support": "^2.26.0",
     "appium-xcode": "^3.1.0",
     "asyncbox": "^2.3.1",
     "lodash": "^4.2.1",

--- a/test/simctl-e2e-specs.js
+++ b/test/simctl-e2e-specs.js
@@ -16,7 +16,7 @@ const should = chai.should();
 chai.use(chaiAsPromised);
 
 describe('simctl', function () {
-  const DEVICE_NAME = 'iPhone 6';
+  const DEVICE_NAME = process.env.DEVICE_NAME || 'iPhone 6';
   const MOCHA_TIMEOUT = 200000;
   this.timeout(MOCHA_TIMEOUT);
 

--- a/test/simctl-specs.js
+++ b/test/simctl-specs.js
@@ -3,7 +3,7 @@ import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import * as TeenProcess from 'teen_process';
 import _ from 'lodash';
-import { getDevices } from '../lib/simctl';
+import { getDevices, createDevice } from '../lib/simctl';
 
 
 const devicePayloads = [
@@ -29,8 +29,9 @@ chai.should();
 chai.use(chaiAsPromised);
 
 describe('simctl', function () {
+  const execStub = sinon.stub(TeenProcess, 'exec');
+
   describe('getDevices', function () {
-    const execStub = sinon.stub(TeenProcess, 'exec');
     afterEach(function () {
       execStub.resetHistory();
     });
@@ -114,5 +115,72 @@ describe('simctl', function () {
         });
       });
     }
+  });
+
+  describe('#createDevice', function () {
+    const devicesPayload = devicePayloads[0][0];
+    afterEach(function () {
+      execStub.resetHistory();
+    });
+    after(function () {
+      execStub.reset();
+    });
+
+    it('should create iOS simulator by default', async function () {
+      execStub.onFirstCall().returns({stdout: 'com.apple.CoreSimulator.SimRuntime.iOS-12-1', stderr: ''})
+              .onSecondCall().returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
+              .onThirdCall().returns(devicesPayload);
+
+      const devices = await createDevice(
+        'name',
+        'iPhone 6 Plus',
+        '12.1',
+        20000
+      );
+      execStub.secondCall.args[1].should.eql([
+        'simctl', 'create', 'name', 'iPhone 6 Plus', 'com.apple.CoreSimulator.SimRuntime.iOS-12-1'
+      ]);
+      devices.should.eql('EE76EA77-E975-4198-9859-69DFF74252D2');
+    });
+
+    it('should create tvOS simulator', async function () {
+      execStub.onFirstCall().returns({stdout: 'com.apple.CoreSimulator.SimRuntime.tvOS-12-1', stderr: ''})
+              .onSecondCall().returns({stdout: 'FA628127-1D5C-45C3-9918-A47BF7E2AE14', stderr: ''})
+              .onThirdCall().returns(devicesPayload);
+
+      const devices = await createDevice(
+        'name',
+        'Apple TV',
+        '12.1',
+        20000,
+        { platform: 'tvOS' }
+      );
+      execStub.secondCall.args[1].should.eql([
+        'simctl', 'create', 'name', 'Apple TV', 'com.apple.CoreSimulator.SimRuntime.tvOS-12-1'
+      ]);
+      devices.should.eql('FA628127-1D5C-45C3-9918-A47BF7E2AE14');
+    });
+
+    it('should create iOS simulator by default with old format', async function () {
+      execStub.onFirstCall().returns({stdout: 'com.apple.CoreSimulator.SimRuntime.iOS-12-1', stderr: ''})
+              .onSecondCall().throws('Incompatible device')
+              .onThirdCall().returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
+              .onCall(3).returns(devicesPayload);
+
+      const devices = await createDevice(
+        'name',
+        'iPhone 6 Plus',
+        '12.1',
+        20000
+      );
+      execStub.secondCall.args[1].should.eql([
+        'simctl', 'create', 'name', 'iPhone 6 Plus', 'com.apple.CoreSimulator.SimRuntime.iOS-12-1'
+      ]);
+      execStub.thirdCall.args[1].should.eql([
+        'simctl', 'create', 'name', 'iPhone 6 Plus', '12.1'
+      ]);
+      devices.should.eql('EE76EA77-E975-4198-9859-69DFF74252D2');
+    });
+
   });
 });

--- a/test/simctl-specs.js
+++ b/test/simctl-specs.js
@@ -139,7 +139,7 @@ describe('simctl', function () {
         'name',
         'iPhone 6 Plus',
         '12.1',
-        20000
+        { timeout: 20000 }
       );
       execStub.secondCall.args[1].should.eql([
         'simctl', 'create', 'name', 'iPhone 6 Plus', 'com.apple.CoreSimulator.SimRuntime.iOS-12-1'
@@ -157,8 +157,7 @@ describe('simctl', function () {
         'name',
         'Apple TV',
         '12.1',
-        20000,
-        { platform: 'tvOS' }
+        { timeout: 20000, platform: 'tvOS' }
       );
       execStub.secondCall.args[1].should.eql([
         'simctl', 'create', 'name', 'Apple TV', 'com.apple.CoreSimulator.SimRuntime.tvOS-12-1'
@@ -176,7 +175,7 @@ describe('simctl', function () {
         'name',
         'iPhone 6 Plus',
         '12.1',
-        20000
+        { timeout: 20000 }
       );
       execStub.secondCall.args[1].should.eql([
         'simctl', 'create', 'name', 'iPhone 6 Plus', '12.1'

--- a/test/simctl-specs.js
+++ b/test/simctl-specs.js
@@ -120,6 +120,7 @@ describe('simctl', function () {
   describe('#createDevice', function () {
     const devicesPayload = devicePayloads[0][0];
     const getCLTVersionStub = sinon.stub(xcode, 'getCommandLineToolsVersion');
+    const getXcodeVersionStub = sinon.stub(xcode, 'getVersion');
     afterEach(function () {
       execStub.resetHistory();
       getCLTVersionStub.resetHistory();
@@ -165,11 +166,31 @@ describe('simctl', function () {
       devices.should.eql('FA628127-1D5C-45C3-9918-A47BF7E2AE14');
     });
 
-    it('should create iOS simulator by default with old format', async function () {
+    it('should create iOS simulator by default with lower command line tool but newer xcode version', async function () {
       execStub.onFirstCall().returns({stdout: '12.1', stderr: ''})
               .onSecondCall().returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
               .onCall(3).returns(devicesPayload);
       getCLTVersionStub.returns('10.1.0.0.1.1552586384');
+      getXcodeVersionStub.returns('10.1');
+
+      const devices = await createDevice(
+        'name',
+        'iPhone 6 Plus',
+        '12.1',
+        { timeout: 20000 }
+      );
+      execStub.secondCall.args[1].should.eql([
+        'simctl', 'create', 'name', 'iPhone 6 Plus', '12.1'
+      ]);
+      devices.should.eql('EE76EA77-E975-4198-9859-69DFF74252D2');
+    });
+
+    it('should create iOS simulator by default with old format', async function () {
+      execStub.onFirstCall().returns({stdout: '12.1', stderr: ''})
+              .onSecondCall().returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
+              .onCall(2).returns(devicesPayload);
+      getCLTVersionStub.returns('10.1.0.0.1.1552586384');
+      getXcodeVersionStub.returns('10.1');
 
       const devices = await createDevice(
         'name',

--- a/test/simctl-specs.js
+++ b/test/simctl-specs.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import * as TeenProcess from 'teen_process';
 import _ from 'lodash';
 import { getDevices, createDevice } from '../lib/simctl';
-
+import * as xcode from 'appium-xcode';
 
 const devicePayloads = [
   [
@@ -119,17 +119,21 @@ describe('simctl', function () {
 
   describe('#createDevice', function () {
     const devicesPayload = devicePayloads[0][0];
+    const getCLTVersionStub = sinon.stub(xcode, 'getCommandLineToolsVersion');
     afterEach(function () {
       execStub.resetHistory();
+      getCLTVersionStub.resetHistory();
     });
     after(function () {
       execStub.reset();
+      getCLTVersionStub.reset();
     });
 
     it('should create iOS simulator by default', async function () {
       execStub.onFirstCall().returns({stdout: 'com.apple.CoreSimulator.SimRuntime.iOS-12-1', stderr: ''})
               .onSecondCall().returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
               .onThirdCall().returns(devicesPayload);
+      getCLTVersionStub.returns('10.2.0.0.1.1552586384');
 
       const devices = await createDevice(
         'name',
@@ -147,6 +151,7 @@ describe('simctl', function () {
       execStub.onFirstCall().returns({stdout: 'com.apple.CoreSimulator.SimRuntime.tvOS-12-1', stderr: ''})
               .onSecondCall().returns({stdout: 'FA628127-1D5C-45C3-9918-A47BF7E2AE14', stderr: ''})
               .onThirdCall().returns(devicesPayload);
+      getCLTVersionStub.returns('10.2.0.0.1.1552586384');
 
       const devices = await createDevice(
         'name',
@@ -162,10 +167,10 @@ describe('simctl', function () {
     });
 
     it('should create iOS simulator by default with old format', async function () {
-      execStub.onFirstCall().returns({stdout: 'com.apple.CoreSimulator.SimRuntime.iOS-12-1', stderr: ''})
-              .onSecondCall().throws('Incompatible device')
-              .onThirdCall().returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
+      execStub.onFirstCall().returns({stdout: '12.1', stderr: ''})
+              .onSecondCall().returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
               .onCall(3).returns(devicesPayload);
+      getCLTVersionStub.returns('10.1.0.0.1.1552586384');
 
       const devices = await createDevice(
         'name',
@@ -174,9 +179,6 @@ describe('simctl', function () {
         20000
       );
       execStub.secondCall.args[1].should.eql([
-        'simctl', 'create', 'name', 'iPhone 6 Plus', 'com.apple.CoreSimulator.SimRuntime.iOS-12-1'
-      ]);
-      execStub.thirdCall.args[1].should.eql([
         'simctl', 'create', 'name', 'iPhone 6 Plus', '12.1'
       ]);
       devices.should.eql('EE76EA77-E975-4198-9859-69DFF74252D2');

--- a/test/simctl-specs.js
+++ b/test/simctl-specs.js
@@ -130,7 +130,7 @@ describe('simctl', function () {
     });
 
     it('should create iOS simulator by default', async function () {
-      execStub.onFirstCall().returns({stdout: 'com.apple.CoreSimulator.SimRuntime.iOS-12-1', stderr: ''})
+      execStub.onFirstCall().returns({stdout: 'com.apple.CoreSimulator.SimRuntime.iOS-12-1-1', stderr: ''})
               .onSecondCall().returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
               .onThirdCall().returns(devicesPayload);
       getCLTVersionStub.returns('10.2.0.0.1.1552586384');
@@ -138,11 +138,11 @@ describe('simctl', function () {
       const devices = await createDevice(
         'name',
         'iPhone 6 Plus',
-        '12.1',
+        '12.1.1',
         { timeout: 20000 }
       );
       execStub.secondCall.args[1].should.eql([
-        'simctl', 'create', 'name', 'iPhone 6 Plus', 'com.apple.CoreSimulator.SimRuntime.iOS-12-1'
+        'simctl', 'create', 'name', 'iPhone 6 Plus', 'com.apple.CoreSimulator.SimRuntime.iOS-12-1-1'
       ]);
       devices.should.eql('EE76EA77-E975-4198-9859-69DFF74252D2');
     });


### PR DESCRIPTION
After installing Xcode 10.2, the creating format should be `com.apple.CoreSimulator.SimRuntime.iOS-XX-X` instead of `XX.X`. The format is the same even we change the xcode version as 10.1 with `xcode-select`. Thus, I follow this logic, try to call the new format once and if an error raises, try to call old format.

- new format
```
$ xcrun simctl create 'iPhone XS 2'  com.apple.CoreSimulator.SimDeviceType.iPhone-8 com.apple.CoreSimulator.SimRuntime.iOS-12-1
7CD85972-2FB1-4236-B4E9-A2017AB00959
```

- old format
```
$ xcrun simctl create 'iPhone XS 2'  com.apple.CoreSimulator.SimDeviceType.iPhone-8 12.1
An error was encountered processing the command (domain=com.apple.CoreSimulator.SimError, code=162):
Incompatible device
```

Will update xcuitest-driver after this like https://github.com/appium/appium-xcuitest-driver/pull/916/files#diff-bdfd0d2726c6301f92259c6fe3d4928eL21

https://github.com/search?q=org%3Aappium+createDevice&type=Code