### PR TITLE
Fix Command Line Tools version verification

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -357,8 +357,7 @@ async function createDevice (name, deviceTypeId, runtimeId, opts = {}) {
     timeout = DEFAULT_CREATE_SIMULATOR_TIMEOUT
   } = opts;
 
-  let udid;
-  // first make sure that the runtime id is the right one
+  // at first make sure that the runtime id is the right one
   // in some versions of Xcode it will be a patch version
   try {
     runtimeId = await getRuntimeForPlatformVersion(runtimeId, platform);
@@ -369,20 +368,22 @@ async function createDevice (name, deviceTypeId, runtimeId, opts = {}) {
   const clangVersion = await getClangVersion();
   // 1st comparison: clangVersion
   // Command line tools version is 10.2+, but xcode 10.1 can happen
-  let isIdFormatChanged = clangVersion && util.compareVersions(clangVersion, '>=', CMDLINE_TOOLS_CLANG_FORMAT_CHANGED_VERSION);
-  if (!isIdFormatChanged) {
+  let isNewerIdFormatRequired = clangVersion && util.compareVersions(clangVersion, '>=',
+    CMDLINE_TOOLS_CLANG_FORMAT_CHANGED_VERSION);
+  if (!isNewerIdFormatRequired) {
     // 2nd comparison: getVersion
     // The opposite can also happen,
     // but the combination of 10.2 command line tools and lower Xcode version happens more frequently
-    // On Travis's Xcode 10.2 image happens, for instance
     const xcodeVersion = await getVersion(false);
-    isIdFormatChanged = xcodeVersion && util.compareVersions(xcodeVersion, '>=', XCODE_FORMAT_CHANGED_VERSION);
+    isNewerIdFormatRequired = xcodeVersion && util.compareVersions(xcodeVersion, '>=',
+      XCODE_FORMAT_CHANGED_VERSION);
   }
-  if (isIdFormatChanged) {
+  if (isNewerIdFormatRequired) {
     runtimeId = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace(/\./g, '-')}`;
   }
 
   log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${runtimeId}'`);
+  let udid;
   try {
     const out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
     udid = out.stdout.trim();

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -2,13 +2,13 @@ import { exec, SubProcess } from 'teen_process';
 import { retryInterval, waitForCondition } from 'asyncbox';
 import { logger, fs, tempDir, util } from 'appium-support';
 import _ from 'lodash';
-import { getCommandLineToolsVersion, getVersion } from 'appium-xcode';
+import { getClangVersion, getVersion } from 'appium-xcode';
 
 
 const log = logger.getLogger('simctl');
 
 // command line tools and xcode version can be different
-const CMDLINE_TOOLS_FORMAT_CHANGED_VERSION = '10.2';
+const CMDLINE_TOOLS_CLANG_FORMAT_CHANGED_VERSION = '1001.0.46';
 const XCODE_FORMAT_CHANGED_VERSION = '10.2';
 
 const SIM_RUNTIME_NAME = 'com.apple.CoreSimulator.SimRuntime.';
@@ -366,15 +366,19 @@ async function createDevice (name, deviceTypeId, runtimeId, opts = {}) {
     log.warn(`Unable to find runtime for iOS '${runtimeId}'. Continuing`);
   }
 
-  if (util.compareVersions(await getCommandLineToolsVersion(), '>=', CMDLINE_TOOLS_FORMAT_CHANGED_VERSION)
-      || util.compareVersions(await getVersion(false), '>=', XCODE_FORMAT_CHANGED_VERSION)) {
-    // 1st comparison: getCommandLineToolsVersion
-    // Command line tool version is 10.2+, but xcode 10.1 can happen
-
+  const clangVersion = await getClangVersion();
+  // 1st comparison: clangVersion
+  // Command line tools version is 10.2+, but xcode 10.1 can happen
+  let isIdFormatChanged = clangVersion && util.compareVersions(clangVersion, '>=', CMDLINE_TOOLS_CLANG_FORMAT_CHANGED_VERSION);
+  if (!isIdFormatChanged) {
     // 2nd comparison: getVersion
-    // The opposit also can happen,
-    // but the combination of 10.2 command line tool and lower Xcode version happens frequently than this case
+    // The opposite can also happen,
+    // but the combination of 10.2 command line tools and lower Xcode version happens more frequently
     // On Travis's Xcode 10.2 image happens, for instance
+    const xcodeVersion = await getVersion(false);
+    isIdFormatChanged = xcodeVersion && util.compareVersions(xcodeVersion, '>=', XCODE_FORMAT_CHANGED_VERSION);
+  }
+  if (isIdFormatChanged) {
     runtimeId = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace(/\./g, '-')}`;
   }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "appium-support": "^2.26.0",
-    "appium-xcode": "^3.1.0",
+    "appium-xcode": "^3.8.0",
     "asyncbox": "^2.3.1",
     "lodash": "^4.2.1",
     "source-map-support": "^0.5.5",

--- a/test/simctl-specs.js
+++ b/test/simctl-specs.js
@@ -119,22 +119,22 @@ describe('simctl', function () {
 
   describe('#createDevice', function () {
     const devicesPayload = devicePayloads[0][0];
-    const getCLTVersionStub = sinon.stub(xcode, 'getCommandLineToolsVersion');
+    const getClangVersionStub = sinon.stub(xcode, 'getClangVersion');
     const getXcodeVersionStub = sinon.stub(xcode, 'getVersion');
     afterEach(function () {
       execStub.resetHistory();
-      getCLTVersionStub.resetHistory();
+      getClangVersionStub.resetHistory();
     });
     after(function () {
       execStub.reset();
-      getCLTVersionStub.reset();
+      getClangVersionStub.reset();
     });
 
     it('should create iOS simulator by default', async function () {
       execStub.onFirstCall().returns({stdout: 'com.apple.CoreSimulator.SimRuntime.iOS-12-1-1', stderr: ''})
               .onSecondCall().returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
               .onThirdCall().returns(devicesPayload);
-      getCLTVersionStub.returns('10.2.0.0.1.1552586384');
+      getClangVersionStub.returns('1001.0.46.3');
 
       const devices = await createDevice(
         'name',
@@ -152,7 +152,7 @@ describe('simctl', function () {
       execStub.onFirstCall().returns({stdout: 'com.apple.CoreSimulator.SimRuntime.tvOS-12-1', stderr: ''})
               .onSecondCall().returns({stdout: 'FA628127-1D5C-45C3-9918-A47BF7E2AE14', stderr: ''})
               .onThirdCall().returns(devicesPayload);
-      getCLTVersionStub.returns('10.2.0.0.1.1552586384');
+      getClangVersionStub.returns('1001.0.46.4');
 
       const devices = await createDevice(
         'name',
@@ -170,7 +170,7 @@ describe('simctl', function () {
       execStub.onFirstCall().returns({stdout: '12.1', stderr: ''})
               .onSecondCall().returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
               .onCall(3).returns(devicesPayload);
-      getCLTVersionStub.returns('10.1.0.0.1.1552586384');
+      getClangVersionStub.returns('1000.11.45.5');
       getXcodeVersionStub.returns('10.1');
 
       const devices = await createDevice(
@@ -189,7 +189,7 @@ describe('simctl', function () {
       execStub.onFirstCall().returns({stdout: '12.1', stderr: ''})
               .onSecondCall().returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
               .onCall(2).returns(devicesPayload);
-      getCLTVersionStub.returns('10.1.0.0.1.1552586384');
+      getClangVersionStub.returns('1000.11.45.5');
       getXcodeVersionStub.returns('10.1');
 
       const devices = await createDevice(


### PR DESCRIPTION
Fixes the exception when `getCommandLineToolsVersion` is unable to retrieve CLT version. Based on https://github.com/appium/appium-xcode/pull/48