### PR TITLE
fix: Use --json flag to get runtime

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -624,8 +624,7 @@ async function getRuntimeForPlatformVersion (platformVersion, platform = 'iOS') 
   // Try it with --json flag
   try {
     const {stdout} = await simExec('list', 0, ['runtimes', '--json']);
-    for (let runtime of JSON.parse(stdout).runtimes) {
-      const {version, identifier, name} = runtime;
+    for (const {version, identifier, name} of JSON.parse(stdout).runtimes) {
       if (version === platformVersion && name.toLowerCase().startsWith(platform.toLowerCase())) {
         return identifier;
       }

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -621,6 +621,18 @@ async function getDevices (forSdk, platform) {
  *                  platform version.
  */
 async function getRuntimeForPlatformVersion (platformVersion, platform = 'iOS') {
+  // Try it with --json flag
+  try {
+    const {stdout} = await simExec('list', 0, ['runtimes', '--json']);
+    for (let runtime of JSON.parse(stdout).runtimes) {
+      const {version, identifier, name} = runtime;
+      if (version === platformVersion && name.toLowerCase().startsWith(platform.toLowerCase())) {
+        return identifier;
+      }
+    }
+  } catch (ign) {}
+
+  // Try with parsing
   try {
     const {stdout} = await simExec('list', 0, ['runtimes']);
     // https://regex101.com/r/UykjQZ/1

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -357,29 +357,40 @@ async function createDevice (name, deviceTypeId, runtimeId, opts = {}) {
     timeout = DEFAULT_CREATE_SIMULATOR_TIMEOUT
   } = opts;
 
-  // at first make sure that the runtime id is the right one
-  // in some versions of Xcode it will be a patch version
+  // Try getting runtimeId using JSON flag
+  let runtimeIdFromJson;
   try {
-    runtimeId = await getRuntimeForPlatformVersion(runtimeId, platform);
-  } catch (err) {
-    log.warn(`Unable to find runtime for iOS '${runtimeId}'. Continuing`);
-  }
+    runtimeIdFromJson = await getRuntimeForPlatformVersionViaJson(runtimeId, platform);
+    runtimeId = runtimeIdFromJson;
+  } catch (ign) { }
 
-  const clangVersion = await getClangVersion();
-  // 1st comparison: clangVersion
-  // Command line tools version is 10.2+, but xcode 10.1 can happen
-  let isNewerIdFormatRequired = clangVersion && util.compareVersions(clangVersion, '>=',
-    CMDLINE_TOOLS_CLANG_FORMAT_CHANGED_VERSION);
-  if (!isNewerIdFormatRequired) {
-    // 2nd comparison: getVersion
-    // The opposite can also happen,
-    // but the combination of 10.2 command line tools and lower Xcode version happens more frequently
-    const xcodeVersion = await getVersion(false);
-    isNewerIdFormatRequired = xcodeVersion && util.compareVersions(xcodeVersion, '>=',
-      XCODE_FORMAT_CHANGED_VERSION);
-  }
-  if (isNewerIdFormatRequired) {
-    runtimeId = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace(/\./g, '-')}`;
+  if (!runtimeIdFromJson) {
+    // at first make sure that the runtime id is the right one
+    // in some versions of Xcode it will be a patch version
+    try {
+      runtimeId = await getRuntimeForPlatformVersion(runtimeId, platform);
+    } catch (err) {
+      log.warn(`Unable to find runtime for iOS '${runtimeId}'. Continuing`);
+    }
+
+    const clangVersion = await getClangVersion();
+    // 1st comparison: clangVersion
+    // Command line tools version is 10.2+, but xcode 10.1 can happen
+    let isNewerIdFormatRequired = clangVersion && util.compareVersions(clangVersion, '>=',
+      CMDLINE_TOOLS_CLANG_FORMAT_CHANGED_VERSION);
+
+    if (!isNewerIdFormatRequired) {
+      // 2nd comparison: getVersion
+      // The opposite can also happen,
+      // but the combination of 10.2 command line tools and lower Xcode version happens more frequently
+      const xcodeVersion = await getVersion(false);
+      isNewerIdFormatRequired = xcodeVersion && util.compareVersions(xcodeVersion, '>=',
+        XCODE_FORMAT_CHANGED_VERSION);
+    }
+
+    if (isNewerIdFormatRequired) {
+      runtimeId = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace(/\./g, '-')}`;
+    }
   }
 
   log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${runtimeId}'`);
@@ -610,6 +621,24 @@ async function getDevices (forSdk, platform) {
   throw new Error(errMsg);
 }
 
+/**
+ * Get the runtime for the particular platform version using --json flag
+ *
+ * @param {string} platformVersion - The platform version name,
+ *                                   for example '10.3'.
+ * @param {?string} platform - The platform name, for example 'watchOS'.
+ * @return {string} The corresponding runtime name for the given
+ *                  platform version.
+ */
+async function getRuntimeForPlatformVersionViaJson (platformVersion, platform = 'iOS') {
+  const {stdout} = await simExec('list', 0, ['runtimes', '--json']);
+  for (const {version, identifier, name} of JSON.parse(stdout).runtimes) {
+    if (version === platformVersion && name.toLowerCase().startsWith(platform.toLowerCase())) {
+      return identifier;
+    }
+  }
+  throw new Error(`Could not use --json flag to parse platform version`);
+}
 
 /**
  * Get the runtime for the particular platform version.
@@ -621,16 +650,6 @@ async function getDevices (forSdk, platform) {
  *                  platform version.
  */
 async function getRuntimeForPlatformVersion (platformVersion, platform = 'iOS') {
-  // Try it with --json flag
-  try {
-    const {stdout} = await simExec('list', 0, ['runtimes', '--json']);
-    for (const {version, identifier, name} of JSON.parse(stdout).runtimes) {
-      if (version === platformVersion && name.toLowerCase().startsWith(platform.toLowerCase())) {
-        return identifier;
-      }
-    }
-  } catch (ign) {}
-
   // Try with parsing
   try {
     const {stdout} = await simExec('list', 0, ['runtimes']);

--- a/test/simctl-e2e-specs.js
+++ b/test/simctl-e2e-specs.js
@@ -33,7 +33,7 @@ describe('simctl', function () {
       throw new Error('No valid SDKs');
     }
     console.log(`Found valid SDKs: ${validSdks.join(', ')}`); // eslint-disable-line no-console
-    sdk = process.env.SDK || _.last(validSdks);
+    sdk = process.env.IOS_SDK || _.last(validSdks);
 
     // need to find a random name that does not already exist
     // give it 5 tries
@@ -141,7 +141,7 @@ describe('simctl', function () {
         return this.skip();
       }
 
-      const sdk = process.env.SDK || _.last(validSdks);
+      const sdk = process.env.IOS_SDK || _.last(validSdks);
       udid = await createDevice('runningSimTest', DEVICE_NAME, sdk);
 
       await bootDevice(udid);

--- a/test/simctl-e2e-specs.js
+++ b/test/simctl-e2e-specs.js
@@ -33,7 +33,7 @@ describe('simctl', function () {
       throw new Error('No valid SDKs');
     }
     console.log(`Found valid SDKs: ${validSdks.join(', ')}`); // eslint-disable-line no-console
-    sdk = _.last(validSdks);
+    sdk = process.env.SDK || _.last(validSdks);
 
     // need to find a random name that does not already exist
     // give it 5 tries
@@ -141,7 +141,7 @@ describe('simctl', function () {
         return this.skip();
       }
 
-      const sdk = _.last(validSdks);
+      const sdk = process.env.SDK || _.last(validSdks);
       udid = await createDevice('runningSimTest', DEVICE_NAME, sdk);
 
       await bootDevice(udid);

--- a/test/simctl-specs.js
+++ b/test/simctl-specs.js
@@ -131,9 +131,10 @@ describe('simctl', function () {
     });
 
     it('should create iOS simulator by default', async function () {
-      execStub.onFirstCall().returns({stdout: 'com.apple.CoreSimulator.SimRuntime.iOS-12-1-1', stderr: ''})
-              .onSecondCall().returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
-              .onThirdCall().returns(devicesPayload);
+      execStub.onCall(0).returns({stdout: 'not json'})
+              .onCall(1).returns({stdout: 'com.apple.CoreSimulator.SimRuntime.iOS-12-1-1', stderr: ''})
+              .onCall(2).returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
+              .onCall(3).returns(devicesPayload);
       getClangVersionStub.returns('1001.0.46.3');
 
       const devices = await createDevice(
@@ -142,16 +143,17 @@ describe('simctl', function () {
         '12.1.1',
         { timeout: 20000 }
       );
-      execStub.secondCall.args[1].should.eql([
+      execStub.getCall(2).args[1].should.eql([
         'simctl', 'create', 'name', 'iPhone 6 Plus', 'com.apple.CoreSimulator.SimRuntime.iOS-12-1-1'
       ]);
       devices.should.eql('EE76EA77-E975-4198-9859-69DFF74252D2');
     });
 
     it('should create tvOS simulator', async function () {
-      execStub.onFirstCall().returns({stdout: 'com.apple.CoreSimulator.SimRuntime.tvOS-12-1', stderr: ''})
-              .onSecondCall().returns({stdout: 'FA628127-1D5C-45C3-9918-A47BF7E2AE14', stderr: ''})
-              .onThirdCall().returns(devicesPayload);
+      execStub.onCall(0).returns({stdout: 'invalid json'})
+              .onCall(1).returns({stdout: 'com.apple.CoreSimulator.SimRuntime.tvOS-12-1', stderr: ''})
+              .onCall(2).returns({stdout: 'FA628127-1D5C-45C3-9918-A47BF7E2AE14', stderr: ''})
+              .onCall(3).returns(devicesPayload);
       getClangVersionStub.returns('1001.0.46.4');
 
       const devices = await createDevice(
@@ -160,15 +162,16 @@ describe('simctl', function () {
         '12.1',
         { timeout: 20000, platform: 'tvOS' }
       );
-      execStub.secondCall.args[1].should.eql([
+      execStub.getCall(2).args[1].should.eql([
         'simctl', 'create', 'name', 'Apple TV', 'com.apple.CoreSimulator.SimRuntime.tvOS-12-1'
       ]);
       devices.should.eql('FA628127-1D5C-45C3-9918-A47BF7E2AE14');
     });
 
     it('should create iOS simulator by default with lower command line tool but newer xcode version', async function () {
-      execStub.onFirstCall().returns({stdout: '12.1', stderr: ''})
-              .onSecondCall().returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
+      execStub.onCall(0).returns({stdout: 'invalid json'})
+              .onCall(1).returns({stdout: '12.1', stderr: ''})
+              .onCall(2).returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
               .onCall(3).returns(devicesPayload);
       getClangVersionStub.returns('1000.11.45.5');
       getXcodeVersionStub.returns('10.1');
@@ -179,16 +182,17 @@ describe('simctl', function () {
         '12.1',
         { timeout: 20000 }
       );
-      execStub.secondCall.args[1].should.eql([
+      execStub.getCall(2).args[1].should.eql([
         'simctl', 'create', 'name', 'iPhone 6 Plus', '12.1'
       ]);
       devices.should.eql('EE76EA77-E975-4198-9859-69DFF74252D2');
     });
 
     it('should create iOS simulator by default with old format', async function () {
-      execStub.onFirstCall().returns({stdout: '12.1', stderr: ''})
-              .onSecondCall().returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
-              .onCall(2).returns(devicesPayload);
+      execStub.onCall(0).returns({stdout: 'invalid json'})
+              .onCall(1).returns({stdout: '12.1', stderr: ''})
+              .onCall(2).returns({stdout: 'EE76EA77-E975-4198-9859-69DFF74252D2', stderr: ''})
+              .onCall(3).returns(devicesPayload);
       getClangVersionStub.returns('1000.11.45.5');
       getXcodeVersionStub.returns('10.1');
 
@@ -198,7 +202,7 @@ describe('simctl', function () {
         '12.1',
         { timeout: 20000 }
       );
-      execStub.secondCall.args[1].should.eql([
+      execStub.getCall(2).args[1].should.eql([
         'simctl', 'create', 'name', 'iPhone 6 Plus', '12.1'
       ]);
       devices.should.eql('EE76EA77-E975-4198-9859-69DFF74252D2');

--- a/test/simctl-specs.js
+++ b/test/simctl-specs.js
@@ -149,6 +149,49 @@ describe('simctl', function () {
       devices.should.eql('EE76EA77-E975-4198-9859-69DFF74252D2');
     });
 
+    it('should create iOS simulator by default and use xcrun simctl "json" parsing', async function () {
+      const runtimesJson = `{
+        "runtimes" : [
+          {
+            "buildversion" : "15B87",
+            "availability" : "(available)",
+            "name" : "iOS 12.1.1",
+            "identifier" : "com.apple.CoreSimulator.SimRuntime.iOS-12-1-1",
+            "version" : "12.1.1"
+          },
+          {
+            "buildversion" : "15J580",
+            "availability" : "(available)",
+            "name" : "tvOS 11.1",
+            "identifier" : "com.apple.CoreSimulator.SimRuntime.tvOS-11-1",
+            "version" : "11.1"
+          },
+          {
+            "buildversion" : "15R844",
+            "availability" : "(available)",
+            "name" : "watchOS 4.1",
+            "identifier" : "com.apple.CoreSimulator.SimRuntime.watchOS-4-1",
+            "version" : "4.1"
+          }
+        ]
+      }`;
+      execStub.onCall(0).returns({stdout: runtimesJson})
+        .onCall(1).returns({stdout: 'FA628127-1D5C-45C3-9918-A47BF7E2AE14', stderr: ''})
+        .onCall(2).returns(devicesPayload);
+      getClangVersionStub.returns('1.1.1.1');
+
+      const devices = await createDevice(
+        'name',
+        'iPhone 6 Plus',
+        '12.1.1',
+        { timeout: 20000 }
+      );
+      execStub.getCall(1).args[1].should.eql([
+        'simctl', 'create', 'name', 'iPhone 6 Plus', 'com.apple.CoreSimulator.SimRuntime.iOS-12-1-1'
+      ]);
+      devices.should.eql('FA628127-1D5C-45C3-9918-A47BF7E2AE14');
+    });
+
     it('should create tvOS simulator', async function () {
       execStub.onCall(0).returns({stdout: 'invalid json'})
               .onCall(1).returns({stdout: 'com.apple.CoreSimulator.SimRuntime.tvOS-12-1', stderr: ''})


### PR DESCRIPTION
Fixes problems with https://dev.azure.com/AppiumCI/Appium%20CI/_build/results?buildId=5507

Driver Specs were not working because it wasn't parsing correctly. Tries using `--json` flag first.