### PR TITLE
refactor: simplify createDevice logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,18 @@ env:
 matrix:
   include:
     - osx_image: xcode7.3
-    # - osx_image: xcode9.4
-    # - osx_image: xcode10
-    # - osx_image: xcode10.1
-    # - osx_image: xcode10.2
-    #   env:
-    #     - DEVICE_NAME="iPhone X"
-    # - osx_image: xcode10.2
-    #   env:
-    #     - DEVICE_NAME="iPhone X"
-    # - osx_image: xcode11
-    #   env:
-    #     - DEVICE_NAME="iPhone X"
+    - osx_image: xcode9.4
+    - osx_image: xcode10
+    - osx_image: xcode10.1
+    - osx_image: xcode10.2
+      env:
+        - DEVICE_NAME="iPhone X"
+    - osx_image: xcode10.2
+      env:
+        - DEVICE_NAME="iPhone X"
+    - osx_image: xcode11
+      env:
+        - DEVICE_NAME="iPhone X"
 script:
   - xcrun simctl list devices
   - npm run test && _FORCE_LOGS=1 npm run e2e-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,18 @@ env:
 matrix:
   include:
     - osx_image: xcode7.3
-    - osx_image: xcode9.4
-    - osx_image: xcode10
-    - osx_image: xcode10.1
-    - osx_image: xcode10.2
-      env:
-        - DEVICE_NAME="iPhone X"
-    - osx_image: xcode10.2
-      env:
-        - DEVICE_NAME="iPhone X"
-    - osx_image: xcode11
-      env:
-        - DEVICE_NAME="iPhone X"
+    # - osx_image: xcode9.4
+    # - osx_image: xcode10
+    # - osx_image: xcode10.1
+    # - osx_image: xcode10.2
+    #   env:
+    #     - DEVICE_NAME="iPhone X"
+    # - osx_image: xcode10.2
+    #   env:
+    #     - DEVICE_NAME="iPhone X"
+    # - osx_image: xcode11
+    #   env:
+    #     - DEVICE_NAME="iPhone X"
 script:
   - xcrun simctl list devices
   - npm run test && _FORCE_LOGS=1 npm run e2e-test

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -420,7 +420,11 @@ async function createDevice (name, deviceTypeId, platformVersion, opts = {}) {
 
     // first make sure the device exists
     const exists = _.flatten(devices)
-      .filter((device) => device.udid === udid)
+      .filter((device) => {
+        log.debug(`UDID: '${udid}'`);
+        log.debug(`DEVICE: ${JSON.stringify(device)}`);
+        return device.udid === udid;
+      })
       .length === 1;
     if (!exists) {
       throw new Error(`Device with udid '${udid}' not yet created`);

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -416,7 +416,18 @@ async function createDevice (name, deviceTypeId, platformVersion, opts = {}) {
   // make sure that it gets out of the "Creating" state
   const retries = parseInt(timeout / 1000, 10);
   await retryInterval(retries, 1000, async () => {
-    const done = _.values(await getDevices())
+    const devices = _.values(await getDevices());
+
+    // first make sure the device exists
+    const exists = _.flatten(devices)
+      .filter((device) => device.udid === udid)
+      .length === 1;
+    if (!exists) {
+      throw new Error(`Device with udid '${udid}' not yet created`);
+    }
+
+    // then make sure it is done being created
+    const done = _.values(devices)
       .filter((device) => device.udid === udid)
       .every((device) => device.state !== 'Creating');
     if (!done) {

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -375,6 +375,10 @@ async function createDevice (name, deviceTypeId, platformVersion, opts = {}) {
     // compute the `major.minor` version first since Xcode usually has a runtime
     // that does not include the patch version, even if it exists
     const runtimeIdSemver = semver.coerce(runtimeId);
+    if (_.isNil(runtimeIdSemver)) {
+      throw new Error(`Unable to parse runtime id '${runtimeId}'`);
+    }
+
     let potentialRuntimeIds = [`${runtimeIdSemver.major}.${runtimeIdSemver.minor}`];
     if (runtimeId.split('.').length === 3) {
       potentialRuntimeIds.push(runtimeId);

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -417,29 +417,20 @@ async function createDevice (name, deviceTypeId, platformVersion, opts = {}) {
   const retries = parseInt(timeout / 1000, 10);
   await retryInterval(retries, 1000, async () => {
     const devices = _.values(await getDevices());
-
-    // first make sure the device exists
-    const exists = _.flatten(devices)
-      .filter((device) => {
-        // log.debug(`UDID: '${udid}'`);
-        // log.debug(`DEVICE: ${JSON.stringify(device)}`);
-        return device.udid === udid;
-      })
-      .length === 1;
-    if (!exists) {
-      throw new Error(`Device with udid '${udid}' not yet created`);
+    for (const deviceArr of _.values(devices)) {
+      for (const device of deviceArr) {
+        if (device.udid === udid) {
+          if (device.state === 'Creating') {
+            // need to retry
+            throw new Error(`Device with udid '${udid}' still being created`);
+          } else {
+            // stop looking, we're done
+            return;
+          }
+        }
+      }
     }
-
-    // then make sure it is done being created
-    const done = _.values(devices)
-      .filter((device) => device.udid === udid)
-      .every((device) => {
-        log.debug('DEVICE:', JSON.stringify(device));
-        return device.state !== 'Creating';
-      });
-    if (!done) {
-      throw new Error(`Device with udid '${udid}' still being created`);
-    }
+    throw new Error(`Device with udid '${udid}' not yet created`);
   });
 
   return udid;

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -379,18 +379,22 @@ async function createDevice (name, deviceTypeId, platformVersion, opts = {}) {
       throw new Error(`Unable to parse runtime id '${runtimeId}'`);
     }
 
+    // start with major-minor version
     let potentialRuntimeIds = [`${runtimeIdSemver.major}.${runtimeIdSemver.minor}`];
     if (runtimeId.split('.').length === 3) {
+      // add patch version if it exists
       potentialRuntimeIds.push(runtimeId);
     }
-    for (const id of potentialRuntimeIds) {
-      // push the modified version first, since on modern Xcodes this is the one
-      // that is used
-      runtimeIds.push(`${SIM_RUNTIME_NAME}${platform}-${id.replace(/\./g, '-')}`);
-    }
-    runtimeIds.push(...potentialRuntimeIds);
+
+    // add modified versions, since modern Xcodes use this, then the bare
+    // versions, to accomodate older Xcodes
+    runtimeIds.push(
+      ...(potentialRuntimeIds.map((id) => `${SIM_RUNTIME_NAME}${platform}-${id.replace(/\./g, '-')}`)),
+      ...potentialRuntimeIds
+    );
   }
 
+  // go through the runtime ids and try to create a simulator with each
   let udid;
   for (const runtimeId of runtimeIds) {
     log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${runtimeId}'`);
@@ -413,19 +417,11 @@ async function createDevice (name, deviceTypeId, platformVersion, opts = {}) {
   // make sure that it gets out of the "Creating" state
   const retries = parseInt(timeout / 1000, 10);
   await retryInterval(retries, 1000, async () => {
-    let devices = await getDevices();
-    for (const deviceArr of _.values(devices)) {
-      for (const device of deviceArr) {
-        if (device.udid === udid) {
-          if (device.state === 'Creating') {
-            // need to retry
-            throw new Error('Device still being created');
-          } else {
-            // stop looking, we're done
-            return;
-          }
-        }
-      }
+    const done = _.values(await getDevices())
+      .filter((device) => device.udid === udid)
+      .every((device) => device.state !== 'Creating');
+    if (!done) {
+      throw new Error('Device still being created');
     }
   });
 

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -420,7 +420,7 @@ async function createDevice (name, deviceTypeId, platformVersion, opts = {}) {
       .filter((device) => device.udid === udid)
       .every((device) => device.state !== 'Creating');
     if (!done) {
-      throw new Error('Device still being created');
+      throw new Error(`Device with udid '${udid}' still being created`);
     }
   });
 

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -1,15 +1,11 @@
 import { exec, SubProcess } from 'teen_process';
 import { retryInterval, waitForCondition } from 'asyncbox';
-import { logger, fs, tempDir, util } from 'appium-support';
+import { logger, fs, tempDir } from 'appium-support';
 import _ from 'lodash';
-import { getClangVersion, getVersion } from 'appium-xcode';
+import semver from 'semver';
 
 
 const log = logger.getLogger('simctl');
-
-// command line tools and xcode version can be different
-const CMDLINE_TOOLS_CLANG_FORMAT_CHANGED_VERSION = '1001.0.46';
-const XCODE_FORMAT_CHANGED_VERSION = '10.2';
 
 const SIM_RUNTIME_NAME = 'com.apple.CoreSimulator.SimRuntime.';
 const SIM_RUNTIME_NAME_SUFFIX_IOS = 'iOS';
@@ -345,70 +341,73 @@ async function shutdown (udid) {
  *
  * @param {string} name - The device name to be created.
  * @param {string} deviceTypeId - Device type, for example 'iPhone 6'.
- * @param {string} runtimeId - Platform version, for example '10.3'.
+ * @param {string} platformVersion - Platform version, for example '10.3'.
  * @param {?SimCreationOpts} opts - Simulator options for creating devices.
  * @return {string} The UDID of the newly created device.
  * @throws {Error} If the corresponding simctl subcommand command
  *                 returns non-zero return code.
  */
-async function createDevice (name, deviceTypeId, runtimeId, opts = {}) {
+async function createDevice (name, deviceTypeId, platformVersion, opts = {}) {
   const {
     platform = SIM_RUNTIME_NAME_SUFFIX_IOS,
     timeout = DEFAULT_CREATE_SIMULATOR_TIMEOUT
   } = opts;
 
+  let runtimeIds = [];
+
   // Try getting runtimeId using JSON flag
-  let runtimeIdFromJson;
   try {
-    runtimeIdFromJson = await getRuntimeForPlatformVersionViaJson(runtimeId, platform);
-    runtimeId = runtimeIdFromJson;
+    runtimeIds.push(await getRuntimeForPlatformVersionViaJson(platformVersion, platform));
   } catch (ign) { }
 
-  if (!runtimeIdFromJson) {
+  if (_.isEmpty(runtimeIds)) {
     // at first make sure that the runtime id is the right one
     // in some versions of Xcode it will be a patch version
+    let runtimeId;
     try {
-      runtimeId = await getRuntimeForPlatformVersion(runtimeId, platform);
+      runtimeId = await getRuntimeForPlatformVersion(platformVersion, platform);
     } catch (err) {
-      log.warn(`Unable to find runtime for iOS '${runtimeId}'. Continuing`);
+      log.warn(`Unable to find runtime for iOS '${platformVersion}'. Continuing`);
+      runtimeId = platformVersion;
     }
 
-    const clangVersion = await getClangVersion();
-    // 1st comparison: clangVersion
-    // Command line tools version is 10.2+, but xcode 10.1 can happen
-    let isNewerIdFormatRequired = clangVersion && util.compareVersions(clangVersion, '>=',
-      CMDLINE_TOOLS_CLANG_FORMAT_CHANGED_VERSION);
-
-    if (!isNewerIdFormatRequired) {
-      // 2nd comparison: getVersion
-      // The opposite can also happen,
-      // but the combination of 10.2 command line tools and lower Xcode version happens more frequently
-      const xcodeVersion = await getVersion(false);
-      isNewerIdFormatRequired = xcodeVersion && util.compareVersions(xcodeVersion, '>=',
-        XCODE_FORMAT_CHANGED_VERSION);
+    // get the possible runtimes, which will be iterated over
+    // compute the `major.minor` version first since Xcode usually has a runtime
+    // that does not include the patch version, even if it exists
+    const runtimeIdSemver = semver.coerce(runtimeId);
+    let potentialRuntimeIds = [`${runtimeIdSemver.major}.${runtimeIdSemver.minor}`];
+    if (runtimeId.split('.').length === 3) {
+      potentialRuntimeIds.push(runtimeId);
     }
+    for (const id of potentialRuntimeIds) {
+      // push the modified version first, since on modern Xcodes this is the one
+      // that is used
+      runtimeIds.push(`${SIM_RUNTIME_NAME}${platform}-${id.replace(/\./g, '-')}`);
+    }
+    runtimeIds.push(...potentialRuntimeIds);
+  }
 
-    if (isNewerIdFormatRequired) {
-      runtimeId = `${SIM_RUNTIME_NAME}${platform}-${runtimeId.replace(/\./g, '-')}`;
+  let udid;
+  for (const runtimeId of runtimeIds) {
+    log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${runtimeId}'`);
+    try {
+      const out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
+      udid = out.stdout.trim();
+      break;
+    } catch (err) {
+      const reason = err.stderr ? err.stderr.trim() : err.message;
+      log.warn(`Unable to create simulator: ${reason}`);
     }
   }
 
-  log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${runtimeId}'`);
-  let udid;
-  try {
-    const out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
-    udid = out.stdout.trim();
-  } catch (err) {
-    let reason = err.message;
-    if (err.stderr) {
-      reason = err.stderr.trim();
-    }
+  if (!udid) {
     log.errorAndThrow(`Could not create simulator with name '${name}', device ` +
-                      `type id '${deviceTypeId}' and runtime id '${runtimeId}'. Reason: '${reason}'`);
+                      `type id '${deviceTypeId}', with runtime ids ` +
+                      `${runtimeIds.map((id) => `'${id}'`).join(', ')}`);
   }
 
   // make sure that it gets out of the "Creating" state
-  let retries = parseInt(timeout / 1000, 10);
+  const retries = parseInt(timeout / 1000, 10);
   await retryInterval(retries, 1000, async () => {
     let devices = await getDevices();
     for (const deviceArr of _.values(devices)) {

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -402,9 +402,8 @@ async function createDevice (name, deviceTypeId, platformVersion, opts = {}) {
       const out = await simExec('create', 0, [name, deviceTypeId, runtimeId]);
       udid = out.stdout.trim();
       break;
-    } catch (err) {
-      const reason = err.stderr ? err.stderr.trim() : err.message;
-      log.warn(`Unable to create simulator: ${reason}`);
+    } catch (ign) {
+      // the error gets logged in `simExec`
     }
   }
 

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -421,8 +421,8 @@ async function createDevice (name, deviceTypeId, platformVersion, opts = {}) {
     // first make sure the device exists
     const exists = _.flatten(devices)
       .filter((device) => {
-        log.debug(`UDID: '${udid}'`);
-        log.debug(`DEVICE: ${JSON.stringify(device)}`);
+        // log.debug(`UDID: '${udid}'`);
+        // log.debug(`DEVICE: ${JSON.stringify(device)}`);
         return device.udid === udid;
       })
       .length === 1;
@@ -433,7 +433,10 @@ async function createDevice (name, deviceTypeId, platformVersion, opts = {}) {
     // then make sure it is done being created
     const done = _.values(devices)
       .filter((device) => device.udid === udid)
-      .every((device) => device.state !== 'Creating');
+      .every((device) => {
+        log.debug('DEVICE:', JSON.stringify(device));
+        return device.state !== 'Creating';
+      });
     if (!done) {
       throw new Error(`Device with udid '${udid}' still being created`);
     }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "appium-xcode": "^3.8.0",
     "asyncbox": "^2.3.1",
     "lodash": "^4.2.1",
+    "semver": "^6.3.0",
     "source-map-support": "^0.5.5",
     "teen_process": "^1.5.1"
   },

--- a/test/simctl-e2e-specs.js
+++ b/test/simctl-e2e-specs.js
@@ -124,7 +124,7 @@ describe('simctl', function () {
       err = e;
     }
     should.exist(err);
-    err.message.should.include('Invalid device type: bar');
+    err.message.should.include(`Unable to parse runtime id 'baz'`);
   });
 
   describe('on running Simulator', function () {


### PR DESCRIPTION
Make sure that we can create simulators when the platform version and runtimes are different (which is mostly to say, when there is a patch version of a sim)

So, if `xcrun simctl list runtimes` returns:
```
== Runtimes ==
iOS 9.3 (9.3 - 13E233) - com.apple.CoreSimulator.SimRuntime.iOS-9-3
iOS 10.3 (10.3.1 - 14E8301) - com.apple.CoreSimulator.SimRuntime.iOS-10-3
iOS 11.0 (11.0.1 - 15A8401) - com.apple.CoreSimulator.SimRuntime.iOS-11-0
iOS 11.1 (11.1 - 15B87) - com.apple.CoreSimulator.SimRuntime.iOS-11-1
iOS 11.2 (11.2 - 15C107) - com.apple.CoreSimulator.SimRuntime.iOS-11-2
iOS 11.3 (11.3 - 15E217) - com.apple.CoreSimulator.SimRuntime.iOS-11-3
iOS 11.4 (11.4 - 15F79) - com.apple.CoreSimulator.SimRuntime.iOS-11-4
iOS 12.0 (12.0 - 16A366) - com.apple.CoreSimulator.SimRuntime.iOS-12-0
iOS 12.1 (12.1 - 16B91) - com.apple.CoreSimulator.SimRuntime.iOS-12-1
iOS 12.2 (12.2 - 16E226) - com.apple.CoreSimulator.SimRuntime.iOS-12-2
iOS 12.4 (12.4 - 16G73) - com.apple.CoreSimulator.SimRuntime.iOS-12-4
iOS 13.0 (13.0 - 17A577) - com.apple.CoreSimulator.SimRuntime.iOS-13-0
iOS 13.1 (13.1 - 17A844) - com.apple.CoreSimulator.SimRuntime.iOS-13-1
iOS 13.2 (13.2.2 - 17B102) - com.apple.CoreSimulator.SimRuntime.iOS-13-2
tvOS 13.2 (13.2 - 17K90) - com.apple.CoreSimulator.SimRuntime.tvOS-13-2
watchOS 6.1 (6.1 - 17S83) - com.apple.CoreSimulator.SimRuntime.watchOS-6-1
```
And someone wants iOS 13.2 it will currently fail because the runtime will be `com.apple.CoreSimulator.SimRuntime.iOS-13-2-2` rather than the correct `com.apple.CoreSimulator.SimRuntime.iOS-13-2`. In this PR it just tries out the various combinations, in order to find the correct one.

In the case of  Xcode `11.2.1`, requesting iOS 13.2, will produce array of possible runtime ids:
```js
[ 
  'com.apple.CoreSimulator.SimRuntime.iOS-13-2',
  'com.apple.CoreSimulator.SimRuntime.iOS-13-2-2',
  '13.2',
  '13.2.2'
 ]
```