### PR TITLE
fix: properly match version from json

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -629,6 +629,7 @@ async function getDevices (forSdk, platform) {
  *
  * @param {string} version - the string version
  * @return {string} The version in 'major.minor' form
+ * @throws {Error} If the version not parseable by the `semver` package
  */
 function normalizeVersion (version) {
   const semverVersion = semver.coerce(version);

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -372,15 +372,9 @@ async function createDevice (name, deviceTypeId, platformVersion, opts = {}) {
     }
 
     // get the possible runtimes, which will be iterated over
-    // compute the `major.minor` version first since Xcode usually has a runtime
-    // that does not include the patch version, even if it exists
-    const runtimeIdSemver = semver.coerce(runtimeId);
-    if (_.isNil(runtimeIdSemver)) {
-      throw new Error(`Unable to parse runtime id '${runtimeId}'`);
-    }
 
     // start with major-minor version
-    let potentialRuntimeIds = [`${runtimeIdSemver.major}.${runtimeIdSemver.minor}`];
+    let potentialRuntimeIds = [normalizeVersion(runtimeId)];
     if (runtimeId.split('.').length === 3) {
       // add patch version if it exists
       potentialRuntimeIds.push(runtimeId);
@@ -628,6 +622,22 @@ async function getDevices (forSdk, platform) {
   throw new Error(errMsg);
 }
 
+
+/**
+ * "Normalize" the version, since iOS uses 'major.minor' but the runtimes can
+ * be 'major.minor.patch'
+ *
+ * @param {string} version - the string version
+ * @return {string} The version in 'major.minor' form
+ */
+function normalizeVersion (version) {
+  version = semver.coerce(version);
+  if (_.isNil(version)) {
+    throw new Error(`Unable to parse version '${version}'`);
+  }
+  return `${version.major}.${version.minor}`;
+}
+
 /**
  * Get the runtime for the particular platform version using --json flag
  *
@@ -640,7 +650,8 @@ async function getDevices (forSdk, platform) {
 async function getRuntimeForPlatformVersionViaJson (platformVersion, platform = 'iOS') {
   const {stdout} = await simExec('list', 0, ['runtimes', '--json']);
   for (const {version, identifier, name} of JSON.parse(stdout).runtimes) {
-    if (version === platformVersion && name.toLowerCase().startsWith(platform.toLowerCase())) {
+    if (normalizeVersion(version) === normalizeVersion(platformVersion)
+      && name.toLowerCase().startsWith(platform.toLowerCase())) {
       return identifier;
     }
   }
@@ -918,5 +929,5 @@ export {
   shutdown, createDevice, getAppContainer, getScreenshot, deleteDevice,
   eraseDevice, getDevices, getRuntimeForPlatformVersion, bootDevice,
   setPasteboard, getPasteboard, addMedia, appInfo, getDeviceTypes,
-  startBootMonitor, getSimctlList
+  startBootMonitor, getSimctlList, normalizeVersion,
 };

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -358,7 +358,7 @@ async function createDevice (name, deviceTypeId, platformVersion, opts = {}) {
   // Try getting runtimeId using JSON flag
   try {
     runtimeIds.push(await getRuntimeForPlatformVersionViaJson(platformVersion, platform));
-  } catch (ign) { }
+  } catch (ign) {}
 
   if (_.isEmpty(runtimeIds)) {
     // at first make sure that the runtime id is the right one
@@ -631,11 +631,11 @@ async function getDevices (forSdk, platform) {
  * @return {string} The version in 'major.minor' form
  */
 function normalizeVersion (version) {
-  version = semver.coerce(version);
-  if (_.isNil(version)) {
+  const semverVersion = semver.coerce(version);
+  if (_.isNil(semverVersion)) {
     throw new Error(`Unable to parse version '${version}'`);
   }
-  return `${version.major}.${version.minor}`;
+  return `${semverVersion.major}.${semverVersion.minor}`;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "mocha": "mocha",
     "coverage": "gulp coveralls",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
-    "lint": "gulp eslint",
+    "lint": "gulp lint",
     "lint:fix": "gulp eslint --fix"
   },
   "pre-commit": [

--- a/test/simctl-e2e-specs.js
+++ b/test/simctl-e2e-specs.js
@@ -124,7 +124,7 @@ describe('simctl', function () {
       err = e;
     }
     should.exist(err);
-    err.message.should.include(`Unable to parse runtime id 'baz'`);
+    err.message.should.include(`Unable to parse version 'baz'`);
   });
 
   describe('on running Simulator', function () {


### PR DESCRIPTION
Check `major.minor` versions of platform and runtime, rather than raw versions.