### PR TITLE
fix: bump DEVICE_NAME const on e2s tests to iPhone X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
 matrix:
   include:
     - osx_image: xcode7.3
+      env:
+        - DEVICE_NAME="iPhone 6"
     - osx_image: xcode9.4
     - osx_image: xcode10
     - osx_image: xcode10.1

--- a/test/simctl-e2e-specs.js
+++ b/test/simctl-e2e-specs.js
@@ -14,7 +14,7 @@ const should = chai.should();
 chai.use(chaiAsPromised);
 
 describe('simctl', function () {
-  const DEVICE_NAME = process.env.DEVICE_NAME || 'iPhone 6';
+  const DEVICE_NAME = process.env.DEVICE_NAME || 'iPhone X';
   const MOCHA_TIMEOUT = 200000;
   this.timeout(MOCHA_TIMEOUT);
 


### PR DESCRIPTION
This PR address a minor issue on e2e test that I found while playing around with the project. 
The const DEVICE_NAME was set to iPhone 6 and tests were failing locally as this is simulator is not available on a cutting edge SimRuntime version (like 13.5). This update also streamlines with the device name used on the CI jobs.