### PR TITLE
chore: Avoid appium-support imports

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,14 @@
-import { logger } from 'appium-support';
+import npmlog from 'npmlog';
 
-const log = logger.getLogger('simctl');
+function getLogger () {
+  const logger = global._global_npmlog || npmlog;
+  logger.maxRecordSize = 3000;
+  if (!logger.debug) {
+    logger.addLevel('debug', 1000, { fg: 'blue', bg: 'black' }, 'dbug');
+  }
+  return logger;
+}
+
+const log = getLogger('simctl');
 
 export default log;

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import subcommands from './subcommands/index.js';
-import { fs } from 'appium-support';
+import which from 'which';
 import log from './logger';
 import {
   DEFAULT_EXEC_TIMEOUT, XCRUN_BINARY,
@@ -81,7 +81,7 @@ class Simctl {
   async requireXcrun () {
     if (!this.xcrun.path) {
       try {
-        this.xcrun.path = await fs.which(XCRUN_BINARY);
+        this.xcrun.path = await which(XCRUN_BINARY);
       } catch (e) {
         throw new Error(`${XCRUN_BINARY} tool has not been found in PATH. ` +
           `Are Xcode developers tools installed?`);

--- a/lib/subcommands/bootstatus.js
+++ b/lib/subcommands/bootstatus.js
@@ -1,5 +1,4 @@
 import log from '../logger';
-import { timing } from 'appium-support';
 import { waitForCondition } from 'asyncbox';
 
 
@@ -82,7 +81,7 @@ commands.startBootMonitor = async function startBootMonitor (opts = {}) {
       }
     }
   };
-  const timer = new timing.Timer().start();
+  const start = process.hrtime();
   if (onFinished) {
     timeoutHandler = setTimeout(stopMonitor, timeout);
   } else {
@@ -95,8 +94,9 @@ commands.startBootMonitor = async function startBootMonitor (opts = {}) {
       }, {waitMs: timeout, intervalMs: 500});
     } catch (err) {
       await stopMonitor();
+      const [seconds] = process.hrtime(start);
       throw new Error(
-        `The simulator ${udid} has failed to finish booting after ${timer.getDuration().asSeconds.toFixed(3)}s. ` +
+        `The simulator ${udid} has failed to finish booting after ${seconds}s. ` +
         `Original status: ${status}`);
     }
   }

--- a/lib/subcommands/io.js
+++ b/lib/subcommands/io.js
@@ -1,7 +1,13 @@
-import { tempDir, fs } from 'appium-support';
+import rimraf from 'rimraf';
+import { v4 as uuidV4 } from 'uuid';
 import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import B from 'bluebird';
 
 const commands = {};
+const rimrafAsync = B.promisify(rimraf);
+const readFileAsync = B.promisify(fs.readFile);
 
 /**
  * Gets base64 screenshot for device
@@ -15,15 +21,14 @@ const commands = {};
  */
 commands.getScreenshot = async function getScreenshot () {
   const udid = this.requireUdid('io screenshot');
-  const tmpRoot = await tempDir.openDir();
+  const pathToScreenshotPng = path.resolve(os.tmpdir(), `${uuidV4()}.png`);
   try {
-    const pathToScreenshotPng = path.resolve(tmpRoot, 'screenshot.png');
     await this.exec('io', {
       args: [udid, 'screenshot', pathToScreenshotPng],
     });
-    return (await fs.readFile(pathToScreenshotPng)).toString('base64');
+    return (await readFileAsync(pathToScreenshotPng)).toString('base64');
   } finally {
-    await fs.rimraf(tmpRoot);
+    await rimrafAsync(pathToScreenshotPng);
   }
 };
 

--- a/lib/subcommands/keychain.js
+++ b/lib/subcommands/keychain.js
@@ -1,22 +1,26 @@
-import { fs, tempDir } from 'appium-support';
+import os from 'os';
+import fs from 'fs';
+import B from 'bluebird';
+import { v4 as uuidV4 } from 'uuid';
 import path from 'path';
 import _ from 'lodash';
-
+import rimraf from 'rimraf';
 
 const commands = {};
+const rimrafAsync = B.promisify(rimraf);
+const writeFileAsync = B.promisify(fs.writeFile);
 
 async function handleRawPayload (payload, onPayloadStored) {
-  const tmpRoot = await tempDir.openDir();
+  const filePath = path.resolve(os.tmpdir(), `${uuidV4()}.pem`);
   try {
-    const filePath = path.resolve(tmpRoot, 'certificate.pem');
     if (_.isBuffer(payload)) {
-      await fs.writeFile(filePath, payload);
+      await writeFileAsync(filePath, payload);
     } else {
-      await fs.writeFile(filePath, payload, 'utf8');
+      await writeFileAsync(filePath, payload, 'utf8');
     }
     await onPayloadStored(filePath);
   } finally {
-    await fs.rimraf(tmpRoot);
+    await rimrafAsync(filePath);
   }
 }
 

--- a/lib/subcommands/push.js
+++ b/lib/subcommands/push.js
@@ -1,7 +1,13 @@
-import { fs, tempDir } from 'appium-support';
+import rimraf from 'rimraf';
+import { v4 as uuidV4 } from 'uuid';
 import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import B from 'bluebird';
 
 const commands = {};
+const rimrafAsync = B.promisify(rimraf);
+const writeFileAsync = B.promisify(fs.writeFile);
 
 /**
  * Send a simulated push notification
@@ -24,15 +30,14 @@ const commands = {};
  * @throws {Error} If the `udid` instance property is unset
  */
 commands.pushNotification = async function pushNotification (payload) {
-  const tmpRoot = await tempDir.openDir();
+  const dstPath = path.resolve(os.tmpdir(), `${uuidV4()}.json`);
   try {
-    const dstPath = path.resolve(tmpRoot, 'apns.json');
-    await fs.writeFile(dstPath, JSON.stringify(payload), 'utf8');
+    await writeFileAsync(dstPath, JSON.stringify(payload), 'utf8');
     await this.exec('push', {
       args: [this.requireUdid('push'), dstPath],
     });
   } finally {
-    await fs.rimraf(tmpRoot);
+    await rimrafAsync(dstPath);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -30,13 +30,16 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-support": "^2.37.0",
-    "appium-xcode": "^3.8.0",
     "asyncbox": "^2.3.1",
+    "bluebird": "^3.5.1",
     "lodash": "^4.2.1",
+    "npmlog": "^4.1.2",
+    "rimraf": "^3.0.0",
     "semver": "^7.0.0",
     "source-map-support": "^0.5.5",
-    "teen_process": "^1.5.1"
+    "teen_process": "^1.5.1",
+    "uuid": "^8.0.0",
+    "which": "^2.0.0"
   },
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
@@ -58,6 +61,7 @@
   "devDependencies": {
     "ajv": "^6.5.3",
     "appium-gulp-plugins": "^5.0.0",
+    "appium-xcode": "^3.8.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "eslint-config-appium": "^4.2.0",

--- a/test/simctl-e2e-specs.js
+++ b/test/simctl-e2e-specs.js
@@ -6,12 +6,19 @@ import chaiAsPromised from 'chai-as-promised';
 import _ from 'lodash';
 import Simctl from '../lib/simctl.js';
 import xcode from 'appium-xcode';
-import { fs, tempDir } from 'appium-support';
 import { retryInterval } from 'asyncbox';
-
+import rimraf from 'rimraf';
+import { v4 as uuidV4 } from 'uuid';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import B from 'bluebird';
 
 const should = chai.should();
 chai.use(chaiAsPromised);
+const rimrafAsync = B.promisify(rimraf);
+const writeFileAsync = B.promisify(fs.writeFile);
+
 
 describe('simctl', function () {
   const DEVICE_NAME = process.env.DEVICE_NAME || 'iPhone X';
@@ -212,12 +219,12 @@ describe('simctl', function () {
         if (major < 8 || (major === 8 && minor < 1)) {
           return this.skip();
         }
-        picturePath = await tempDir.path({prefix: 'pixel', suffix: '.png'});
-        await fs.writeFile(picturePath, Buffer.from(BASE64_PNG, 'base64').toString('binary'), 'binary');
+        picturePath = path.join(os.tmpdir(), `${uuidV4()}.png`);
+        await writeFileAsync(picturePath, Buffer.from(BASE64_PNG, 'base64').toString('binary'), 'binary');
       });
       after(async function () {
-        if (await fs.exists(picturePath)) {
-          await fs.unlink(picturePath);
+        if (picturePath) {
+          await rimrafAsync(picturePath);
         }
       });
       it('should add media files', async function () {


### PR DESCRIPTION
`appium-support` is big and it adds unnecessary overhead if this module is imported by third-parties