### PR TITLE
chore: disable explicit errors logging for getenv calls

### DIFF
--- a/lib/subcommands/getenv.js
+++ b/lib/subcommands/getenv.js
@@ -12,6 +12,7 @@ const commands = {};
 commands.getEnv = async function getEnv (varName) {
   const {stdout, stderr} = await this.exec('getenv', {
     args: [this.requireUdid('getenv'), varName],
+    logErrors: false,
   });
   return stderr ? null : stdout;
 };


### PR DESCRIPTION
Error logging for this endpoint is redundant as we sometimes expect it to fail and this creates excessive and confusing log records