### PR TITLE
chore: Patch the npm logger properly

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,8 +6,8 @@ function getLogger () {
   if (!logger.debug) {
     logger.addLevel('debug', 1000, { fg: 'blue', bg: 'black' }, 'dbug');
   }
-  const _originalLog = logger.log.bind(logger);
-  logger.log = (level, prefix, ...args) => _originalLog(level, 'simctl', prefix, ...args);
+  const originalLog = logger.log.bind(logger);
+  logger.log = (level, prefix, ...args) => originalLog(level, 'simctl', prefix, ...args);
   return logger;
 }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,9 +6,11 @@ function getLogger () {
   if (!logger.debug) {
     logger.addLevel('debug', 1000, { fg: 'blue', bg: 'black' }, 'dbug');
   }
+  const _originalLog = logger.log;
+  logger.log = (level, prefix, ...args) => _originalLog(level, 'simctl', prefix, ...args);
   return logger;
 }
 
-const log = getLogger('simctl');
+const log = getLogger();
 
 export default log;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,7 +6,7 @@ function getLogger () {
   if (!logger.debug) {
     logger.addLevel('debug', 1000, { fg: 'blue', bg: 'black' }, 'dbug');
   }
-  const _originalLog = logger.log;
+  const _originalLog = logger.log.bind(logger);
   logger.log = (level, prefix, ...args) => _originalLog(level, 'simctl', prefix, ...args);
   return logger;
 }

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -133,7 +133,7 @@ class Simctl {
         // code do what it wants
         throw e;
       } else if (e.stderr) {
-        const msg = `simctl error running '${subcommand}': ${e.stderr.trim()}`;
+        const msg = `Error running '${subcommand}': ${e.stderr.trim()}`;
         log.debug(msg);
         throw Error(msg);
       } else {


### PR DESCRIPTION
With the current implementation the log message is printed as prefix, which is wrong