### PR TITLE
fix: Avoid global logger patching

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,16 +1,17 @@
 import npmlog from 'npmlog';
 
+
+const LOG_PREFIX = 'simctl';
+
 function getLogger () {
   const logger = global._global_npmlog || npmlog;
-  logger.maxRecordSize = 3000;
   if (!logger.debug) {
     logger.addLevel('debug', 1000, { fg: 'blue', bg: 'black' }, 'dbug');
   }
-  const originalLog = logger.log.bind(logger);
-  logger.log = (level, prefix, ...args) => originalLog(level, 'simctl', prefix, ...args);
   return logger;
 }
 
 const log = getLogger();
 
+export { LOG_PREFIX };
 export default log;

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import subcommands from './subcommands/index.js';
 import which from 'which';
-import log from './logger';
+import log, { LOG_PREFIX } from './logger';
 import {
   DEFAULT_EXEC_TIMEOUT, XCRUN_BINARY,
 } from './helpers';
@@ -134,10 +134,10 @@ class Simctl {
         throw e;
       } else if (e.stderr) {
         const msg = `Error running '${subcommand}': ${e.stderr.trim()}`;
-        log.debug(msg);
+        log.debug(LOG_PREFIX, msg);
         throw Error(msg);
       } else {
-        log.debug(e.message);
+        log.debug(LOG_PREFIX, e.message);
         throw e;
       }
     }

--- a/lib/subcommands/boot.js
+++ b/lib/subcommands/boot.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import log from '../logger';
+import log, { LOG_PREFIX } from '../logger';
 
 
 const commands = {};
@@ -20,7 +20,7 @@ commands.bootDevice = async function bootDevice () {
     if (_.includes(e.message, 'Unable to boot device in current state: Booted')) {
       throw e;
     }
-    log.debug(`Simulator already in 'Booted' state. Continuing`);
+    log.debug(LOG_PREFIX, `Simulator already in 'Booted' state. Continuing`);
   }
 };
 

--- a/lib/subcommands/create.js
+++ b/lib/subcommands/create.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import log from '../logger';
+import log, { LOG_PREFIX } from '../logger';
 import { retryInterval } from 'asyncbox';
 import { SIM_RUNTIME_NAME, normalizeVersion } from '../helpers';
 
@@ -72,7 +72,8 @@ commands.createDevice = async function createDevice (name, deviceTypeId, platfor
   // go through the runtime ids and try to create a simulator with each
   let udid;
   for (const runtimeId of runtimeIds) {
-    log.debug(`Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${runtimeId}'`);
+    log.debug(LOG_PREFIX,
+      `Creating simulator with name '${name}', device type id '${deviceTypeId}' and runtime id '${runtimeId}'`);
     try {
       const {stdout} = await this.exec('create', {
         args: [name, deviceTypeId, runtimeId]

--- a/lib/subcommands/list.js
+++ b/lib/subcommands/list.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { SIM_RUNTIME_NAME, normalizeVersion } from '../helpers';
-import log from '../logger';
+import log, { LOG_PREFIX } from '../logger';
 
 
 const commands = {};
@@ -150,8 +150,8 @@ commands.getDevices = async function getDevices (forSdk, platform) {
       );
     }
   } catch (err) {
-    log.debug(`Unable to get JSON device list: ${err.stack}`);
-    log.debug('Falling back to manual parsing');
+    log.debug(LOG_PREFIX, `Unable to get JSON device list: ${err.stack}`);
+    log.debug(LOG_PREFIX, 'Falling back to manual parsing');
     devices = await this.getDevicesByParsing(platform);
   }
 

--- a/lib/subcommands/shutdown.js
+++ b/lib/subcommands/shutdown.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
-import log from '../logger';
-
+import log, { LOG_PREFIX } from '../logger';
 
 const commands = {};
 
@@ -20,7 +19,7 @@ commands.shutdownDevice = async function shutdownDevice () {
     if (!_.includes(e.message, 'current state: Shutdown')) {
       throw e;
     }
-    log.debug(`Simulator already in 'Shutdown' state. Continuing`);
+    log.debug(LOG_PREFIX, `Simulator already in 'Shutdown' state. Continuing`);
   }
 };
 


### PR DESCRIPTION
It turns out the previous implementation was changing the logger instance globally, which enforced the `simctl` prefix to be added everywhere