### PR TITLE
fix: reopens app after privacy call closes it

### DIFF
--- a/lib/subcommands/privacy.js
+++ b/lib/subcommands/privacy.js
@@ -1,5 +1,11 @@
 const commands = {};
 
+const PERMISSION_VERBS = {
+  GRANT: 'grant',
+  REVOKE: 'revoke',
+  RESET: 'reset',
+};
+
 async function execPrivacyCommand (context, bundleId, permissionVerb, perm) {
   await context.exec('privacy', {
     args: [context.requireUdid(`privacy ${permissionVerb}`), permissionVerb, perm, bundleId],
@@ -33,7 +39,7 @@ async function execPrivacyCommand (context, bundleId, permissionVerb, perm) {
  * @throws {Error} If the `udid` instance property is unset
  */
 commands.grantPermission = async function grantPermission (bundleId, perm) {
-  return await execPrivacyCommand(this, bundleId, 'grant', perm);
+  return await execPrivacyCommand(this, bundleId, PERMISSION_VERBS.GRANT, perm);
 };
 
 /**
@@ -49,7 +55,7 @@ commands.grantPermission = async function grantPermission (bundleId, perm) {
  * @throws {Error} If the `udid` instance property is unset
  */
 commands.revokePermission = async function revokePermission (bundleId, perm) {
-  return await execPrivacyCommand(this, bundleId, 'revoke', perm);
+  return await execPrivacyCommand(this, bundleId, PERMISSION_VERBS.REVOKE, perm);
 };
 
 /**
@@ -65,7 +71,7 @@ commands.revokePermission = async function revokePermission (bundleId, perm) {
  * @throws {Error} If the `udid` instance property is unset
  */
 commands.resetPermission = async function resetPermission (bundleId, perm) {
-  return await execPrivacyCommand(this, bundleId, 'reset', perm);
+  return await execPrivacyCommand(this, bundleId, PERMISSION_VERBS.RESET, perm);
 };
 
 export default commands;

--- a/lib/subcommands/privacy.js
+++ b/lib/subcommands/privacy.js
@@ -10,8 +10,6 @@ async function execPermissionCommand (context, bundleId, permissionVerb, perm) {
   await context.exec('privacy', {
     args: [context.requireUdid(`privacy ${permissionVerb}`), permissionVerb, perm, bundleId],
   });
-  // Changing a permission causes the app to be background'ed. Re-open the app
-  await context.launchApp(bundleId);
 }
 
 /**

--- a/lib/subcommands/privacy.js
+++ b/lib/subcommands/privacy.js
@@ -28,6 +28,8 @@ commands.grantPermission = async function grantPermission (bundleId, perm) {
   await this.exec('privacy', {
     args: [this.requireUdid('privacy grant'), 'grant', perm, bundleId],
   });
+  // Granting a permission causes the app to be background'ed. Re-open the app
+  await this.launchApp(bundleId);
 };
 
 /**
@@ -46,6 +48,8 @@ commands.revokePermission = async function revokePermission (bundleId, perm) {
   await this.exec('privacy', {
     args: [this.requireUdid('privacy revoke'), 'revoke', perm, bundleId],
   });
+  // Revoking a permission causes the app to be background'ed. Re-open the app
+  await this.launchApp(bundleId);
 };
 
 /**

--- a/lib/subcommands/privacy.js
+++ b/lib/subcommands/privacy.js
@@ -6,7 +6,7 @@ const PERMISSION_VERBS = {
   RESET: 'reset',
 };
 
-async function execPrivacyCommand (context, bundleId, permissionVerb, perm) {
+async function execPermissionCommand (context, bundleId, permissionVerb, perm) {
   await context.exec('privacy', {
     args: [context.requireUdid(`privacy ${permissionVerb}`), permissionVerb, perm, bundleId],
   });
@@ -39,7 +39,7 @@ async function execPrivacyCommand (context, bundleId, permissionVerb, perm) {
  * @throws {Error} If the `udid` instance property is unset
  */
 commands.grantPermission = async function grantPermission (bundleId, perm) {
-  return await execPrivacyCommand(this, bundleId, PERMISSION_VERBS.GRANT, perm);
+  return await execPermissionCommand(this, bundleId, PERMISSION_VERBS.GRANT, perm);
 };
 
 /**
@@ -55,7 +55,7 @@ commands.grantPermission = async function grantPermission (bundleId, perm) {
  * @throws {Error} If the `udid` instance property is unset
  */
 commands.revokePermission = async function revokePermission (bundleId, perm) {
-  return await execPrivacyCommand(this, bundleId, PERMISSION_VERBS.REVOKE, perm);
+  return await execPermissionCommand(this, bundleId, PERMISSION_VERBS.REVOKE, perm);
 };
 
 /**
@@ -71,7 +71,7 @@ commands.revokePermission = async function revokePermission (bundleId, perm) {
  * @throws {Error} If the `udid` instance property is unset
  */
 commands.resetPermission = async function resetPermission (bundleId, perm) {
-  return await execPrivacyCommand(this, bundleId, PERMISSION_VERBS.RESET, perm);
+  return await execPermissionCommand(this, bundleId, PERMISSION_VERBS.RESET, perm);
 };
 
 export default commands;

--- a/lib/subcommands/privacy.js
+++ b/lib/subcommands/privacy.js
@@ -1,5 +1,13 @@
 const commands = {};
 
+async function execPrivacyCommand (context, bundleId, permissionVerb, perm) {
+  await context.exec('privacy', {
+    args: [context.requireUdid(`privacy ${permissionVerb}`), permissionVerb, perm, bundleId],
+  });
+  // Changing a permission causes the app to be background'ed. Re-open the app
+  await context.launchApp(bundleId);
+}
+
 /**
  * Grants the given permission on the app with the given bundle identifier
  *
@@ -25,11 +33,7 @@ const commands = {};
  * @throws {Error} If the `udid` instance property is unset
  */
 commands.grantPermission = async function grantPermission (bundleId, perm) {
-  await this.exec('privacy', {
-    args: [this.requireUdid('privacy grant'), 'grant', perm, bundleId],
-  });
-  // Granting a permission causes the app to be background'ed. Re-open the app
-  await this.launchApp(bundleId);
+  return await execPrivacyCommand(this, bundleId, 'grant', perm);
 };
 
 /**
@@ -45,11 +49,7 @@ commands.grantPermission = async function grantPermission (bundleId, perm) {
  * @throws {Error} If the `udid` instance property is unset
  */
 commands.revokePermission = async function revokePermission (bundleId, perm) {
-  await this.exec('privacy', {
-    args: [this.requireUdid('privacy revoke'), 'revoke', perm, bundleId],
-  });
-  // Revoking a permission causes the app to be background'ed. Re-open the app
-  await this.launchApp(bundleId);
+  return await execPrivacyCommand(this, bundleId, 'revoke', perm);
 };
 
 /**
@@ -65,9 +65,7 @@ commands.revokePermission = async function revokePermission (bundleId, perm) {
  * @throws {Error} If the `udid` instance property is unset
  */
 commands.resetPermission = async function resetPermission (bundleId, perm) {
-  await this.exec('privacy', {
-    args: [this.requireUdid('private reset'), 'reset', perm, bundleId],
-  });
+  return await execPrivacyCommand(this, bundleId, 'reset', perm);
 };
 
 export default commands;


### PR DESCRIPTION
Calling `xcrun simctl privacy <udid> <grant|revoke> <permission> <bundle-id>` causes the app `<bundle-id>` to be background'ed. This adds a call to `launchApp(<bundle-id>)` after the permission call is made to bring the app back to the foreground.