### PR TITLE
fix: add missing build/index

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "files": [
     "index.js",
     "lib",
+    "build/index.js",
     "build/lib"
   ],
   "dependencies": {


### PR DESCRIPTION
Needed `build/index.js` to load it as main