### PR TITLE
feat: add timeout option for exec

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -63,6 +63,8 @@ const DEFAULT_OPTS = {
  * command input and outputs.
  * @property {string|string[]} [architectures] - One or more architecture names to be enforced while
  * executing xcrun. See https://github.com/appium/appium/issues/18966 for more details.
+ * @property {number} [timeout] - The maximum number of milliseconds
+ * to wait for single synchronous xcrun command over the execTimeout by SimctlOpts.
  */
 
 /**
@@ -72,7 +74,7 @@ const DEFAULT_OPTS = {
  * the instance to automatically detect the full path to `xcrun` tool and to throw
  * an exception if it cannot be detected. If the path is set upon instance creation
  * then it is going to be used by `exec` and no autodetection will happen.
- * @property {number} [execTimeout=600000] - The maximum number of milliseconds
+ * @property {number} [execTimeout=600000] - The default maximum number of milliseconds
  * to wait for single synchronous xcrun command.
  * @property {boolean} [logErrors=true] - Whether to wire xcrun error messages
  * into debug log before throwing them.
@@ -175,6 +177,7 @@ class Simctl {
       encoding,
       logErrors = true,
       architectures,
+      timeout,
     } = opts ?? {};
     // run a particular simctl command
     args = [
@@ -196,7 +199,11 @@ class Simctl {
       encoding,
     };
     if (!asynchronous) {
-      execOpts.timeout = this.execTimeout;
+      if (timeout) {
+        execOpts.timeout = timeout;
+      } else {
+        execOpts.timeout = this.execTimeout;
+      }
     }
     const xcrun = await this.requireXcrun();
     try {

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -200,11 +200,7 @@ class Simctl {
       encoding,
     };
     if (!asynchronous) {
-      if (timeout) {
-        execOpts.timeout = timeout;
-      } else {
-        execOpts.timeout = this.execTimeout;
-      }
+      execOpts.timeout = timeout || this.execTimeout;
     }
     const xcrun = await this.requireXcrun();
     try {

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -64,7 +64,8 @@ const DEFAULT_OPTS = {
  * @property {string|string[]} [architectures] - One or more architecture names to be enforced while
  * executing xcrun. See https://github.com/appium/appium/issues/18966 for more details.
  * @property {number} [timeout] - The maximum number of milliseconds
- * to wait for single synchronous xcrun command over the execTimeout by SimctlOpts.
+ * to wait for single synchronous xcrun command. If not provided explicitly, then
+ * the value of execTimeout property is used by default.
  */
 
 /**


### PR DESCRIPTION
`Simctl` has default timeout to run `exec` by `teen_process`, but the `exec` method in `Simctl` does not have individual timeout option. It makes sense to let caller to set `timeout` per command and the constructor's timeout is default value for the `Simctl` object wide.

One typical usage is https://github.com/appium/appium-xcuitest-driver/pull/2461