### PR TITLE
feat: add content_size and increase_contrast commands for ui

### DIFF
--- a/lib/subcommands/ui.js
+++ b/lib/subcommands/ui.js
@@ -44,6 +44,7 @@ commands.setAppearance = async function setAppearance (appearance) {
  *   - unsupported: The platform or runtime version do not support the Increase Contrast setting.
  *   - unknown: The current setting is unknown or there was an error detecting it.
  *
+ * @since Xcode 15 (but lower xcode could have this command)
  * @this {import('../simctl').Simctl}
  * @return {Promise<string>} the contrast configuration value.
  *                           Possible return value is 'enabled', 'disabled',
@@ -65,6 +66,7 @@ commands.getIncreaseContrast = async function getIncreaseContrast () {
  * They would change in the future version, so please validate the given value
  * in the caller side.
  *
+ * @since Xcode 15 (but lower xcode could have this command)
  * @this {import('../simctl').Simctl}
  * @param {string} increaseContrast valid increase constrast configuration value.
  *                                  Acceptable value is 'enabled' or 'disabled' with Xcode 16.2.
@@ -88,6 +90,7 @@ commands.setIncreaseContrast = async function setIncreaseContrast (increaseContr
  *                         accessibility-extra-extra-extra-large
  *   Other values: unknown, unsupported.
  *
+ * @since Xcode 15 (but lower xcode could have this command)
  * @this {import('../simctl').Simctl}
  * @return {Promise<string>} the content size value. Possible return value is
  *                           extra-small, small, medium, large, extra-large, extra-extra-large,
@@ -118,6 +121,7 @@ commands.getContentSize = async function getContentSize () {
  * They would change in the future version, so please validate the given value
  * in the caller side.
  *
+ * @since Xcode 15 (but lower xcode could have this command)
  * @this {import('../simctl').Simctl}
  * @param {string} contentSizeAction valid content size or action value. Acceptable value is
  *                                   extra-small, small, medium, large, extra-large, extra-extra-large,

--- a/lib/subcommands/ui.js
+++ b/lib/subcommands/ui.js
@@ -46,6 +46,8 @@ commands.setAppearance = async function setAppearance (appearance) {
  *
  * @this {import('../simctl').Simctl}
  * @return {Promise<string>} the contrast configuration value.
+ *                           Possible return value is 'enabled', 'disabled',
+ *                           'unsupported' or 'unknown' with Xcode 16.2.
  * @throws {Error} if the current SDK version does not support the command
  * or there was an error while getting the value.
  * @throws {Error} If the `udid` instance property is unset
@@ -65,6 +67,7 @@ commands.getIncreaseContrast = async function getIncreaseContrast () {
  *
  * @this {import('../simctl').Simctl}
  * @param {string} increaseContrast valid increase constrast configuration value.
+ *                                  Acceptable value is 'enabled' or 'disabled' with Xcode 16.2.
  * @throws {Error} if the current SDK version does not support the command
  * or the given value was invalid for the command.
  * @throws {Error} If the `udid` instance property is unset
@@ -86,7 +89,12 @@ commands.setIncreaseContrast = async function setIncreaseContrast (increaseContr
  *   Other values: unknown, unsupported.
  *
  * @this {import('../simctl').Simctl}
- * @return {Promise<string>} the content size value.
+ * @return {Promise<string>} the content size value. Possible return value is
+ *                           extra-small, small, medium, large, extra-large, extra-extra-large,
+ *                           extra-extra-extra-large, accessibility-medium, accessibility-large,
+ *                           accessibility-extra-large, accessibility-extra-extra-large,
+ *                           accessibility-extra-extra-extra-large,
+ *                           unknown or unsupported with Xcode 16.2.
  * @throws {Error} if the current SDK version does not support the command
  * or there was an error while getting the value.
  * @throws {Error} If the `udid` instance property is unset
@@ -111,8 +119,11 @@ commands.getContentSize = async function getContentSize () {
  * in the caller side.
  *
  * @this {import('../simctl').Simctl}
- * @param {string} contentSizeAction valid content size or action value.
- *                                   The example is in the description avobe.
+ * @param {string} contentSizeAction valid content size or action value. Acceptable value is
+ *                                   extra-small, small, medium, large, extra-large, extra-extra-large,
+ *                                   extra-extra-extra-large, accessibility-medium, accessibility-large,
+ *                                   accessibility-extra-large, accessibility-extra-extra-large,
+ *                                   accessibility-extra-extra-extra-large with Xcode 16.2.
  * @throws {Error} if the current SDK version does not support the command
  * or the given value was invalid for the command.
  * @throws {Error} If the `udid` instance property is unset

--- a/lib/subcommands/ui.js
+++ b/lib/subcommands/ui.js
@@ -36,4 +36,91 @@ commands.setAppearance = async function setAppearance (appearance) {
   });
 };
 
+/**
+ * Retrieves the current increase contrast configuration value from the given simulator.
+ * The value could be:
+ *   - enabled: Increase Contrast is enabled.
+ *   - disabled: Increase Contrast is disabled.
+ *   - unsupported: The platform or runtime version do not support the Increase Contrast setting.
+ *   - unknown: The current setting is unknown or there was an error detecting it.
+ *
+ * @this {import('../simctl').Simctl}
+ * @return {Promise<string>} the contrast configuration value.
+ * @throws {Error} if the current SDK version does not support the command
+ * or there was an error while getting the value.
+ * @throws {Error} If the `udid` instance property is unset
+ */
+commands.getIncreaseContrast = async function getIncreaseContrast () {
+  const {stdout} = await this.exec('ui', {
+    args: [this.requireUdid('ui'), 'increase_contrast'],
+  });
+  return _.trim(stdout);
+};
+
+/**
+ * Sets the increase constrast configuration for the given simulator.
+ * Acceptable values (with Xcode 16.2, iOS 18.1) are 'enabled' or 'disabled'
+ * They would change in the future version, so please validate the given value
+ * in the caller side.
+ *
+ * @this {import('../simctl').Simctl}
+ * @param {string} increaseContrast valid increase constrast configuration value.
+ * @throws {Error} if the current SDK version does not support the command
+ * or the given value was invalid for the command.
+ * @throws {Error} If the `udid` instance property is unset
+ */
+commands.setIncreaseContrast = async function setIncreaseContrast (increaseContrast) {
+  await this.exec('ui', {
+    args: [this.requireUdid('ui'), 'increase_contrast', increaseContrast],
+  });
+};
+
+/**
+ * Retrieves the current content size value from the given simulator.
+ * The value could be:
+ * 	 Standard sizes: extra-small, small, medium, large, extra-large,
+ *                   extra-extra-large, extra-extra-extra-large
+ *   Extended range sizes: accessibility-medium, accessibility-large,
+ *                         accessibility-extra-large, accessibility-extra-extra-large,
+ *                         accessibility-extra-extra-extra-large
+ *   Other values: unknown, unsupported.
+ *
+ * @this {import('../simctl').Simctl}
+ * @return {Promise<string>} the content size value.
+ * @throws {Error} if the current SDK version does not support the command
+ * or there was an error while getting the value.
+ * @throws {Error} If the `udid` instance property is unset
+ */
+commands.getContentSize = async function getContentSize () {
+  const {stdout} = await this.exec('ui', {
+    args: [this.requireUdid('ui'), 'content_size'],
+  });
+  return _.trim(stdout);
+};
+
+/**
+ * Sets content size for the given simulator.
+ * Acceptable values (with Xcode 16.2, iOS 18.1) are below:
+ * 	 Standard sizes: extra-small, small, medium, large, extra-large,
+ *                   extra-extra-large, extra-extra-extra-large
+ *   Extended range sizes: accessibility-medium, accessibility-large,
+ *                         accessibility-extra-large, accessibility-extra-extra-large,
+ *                         accessibility-extra-extra-extra-large
+ * Or 'increment' or 'decrement'
+ * They would change in the future version, so please validate the given value
+ * in the caller side.
+ *
+ * @this {import('../simctl').Simctl}
+ * @param {string} contentSizeAction valid content size or action value.
+ *                                   The example is in the description avobe.
+ * @throws {Error} if the current SDK version does not support the command
+ * or the given value was invalid for the command.
+ * @throws {Error} If the `udid` instance property is unset
+ */
+commands.setContentSize = async function setContentSize (contentSizeAction) {
+  await this.exec('ui', {
+    args: [this.requireUdid('ui'), 'content_size', contentSizeAction],
+  });
+};
+
 export default commands;


### PR DESCRIPTION
To support https://github.com/appium/appium-xcuitest-driver/issues/2519

Example output:

```
kazu $ xcrun simctl ui "iPhone 16 Plus" content_size
large
kazu $ xcrun simctl ui "iPhone 16 Plus" content_size increment
kazu $ xcrun simctl ui "iPhone 16 Plus" content_size
extra-large
```

```
kazu $ xcrun simctl ui "iPhone 16 Plus" increase_contrast
disabled
kazu $ xcrun simctl ui "iPhone 16 Plus" increase_contrast enabled
kazu $ xcrun simctl ui "iPhone 16 Plus" increase_contrast
enabled
```

Validation for the input will be in the xcuitest driver side similar to appearance https://github.com/appium/appium-xcuitest-driver/blob/1cbd80eb516740945208c049c278aaaa2d014052/lib/commands/appearance.js#L14-L16