### PR TITLE
feat: Bump Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/appium/node-simctl/issues"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   },
   "main": "./build/index.js",
   "bin": {},
@@ -33,14 +33,14 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@appium/logger": "^1.3.0",
+    "@appium/logger": "^2.0.0-rc.1",
     "asyncbox": "^3.0.0",
     "bluebird": "^3.5.1",
     "lodash": "^4.2.1",
-    "rimraf": "^5.0.0",
+    "rimraf": "^6.0.1",
     "semver": "^7.0.0",
     "source-map-support": "^0.x",
-    "teen_process": "^2.2.0",
+    "teen_process": "^3.0.0",
     "uuid": "^11.0.1",
     "which": "^5.0.0"
   },
@@ -61,9 +61,9 @@
     "singleQuote": true
   },
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.x",
-    "@appium/tsconfig": "^0.x",
-    "@appium/types": "^0.x",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
+    "@appium/tsconfig": "^1.0.0-rc.1",
+    "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/bluebird": "^3.5.38",


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10